### PR TITLE
Iteration over all pages in a collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,18 @@ You can find the Java Doc of the latest release here: http://cloud-of-things.git
 
 Short information about what has changed between releases.
 
+### Upcoming Release 1.1.0
+
+* Efficiently iterate over all objects in a collection via Java 8 Stream (accessible via `stream()`): pagination is automatically performed in the background
+* Resolve [issue #72](https://github.com/cloud-of-things/cot-java-rest-sdk/issues/72): Improved paging performance 
+
 ### Release 1.0.5
+
 * Provide functionality to get all SmartREST Templates by X-ID
 * Resolve [issue #52](https://github.com/cloud-of-things/cot-java-rest-sdk/issues/52): provide http status code in thrown exception in getMeasurement()
 
 ### Release 1.0.4
+
 * Improve usage of accept and content-type headers in rest client
 * Improve usage of OkHttpClient so that lesser resources will be used
 * Fix handling of binary data using byte array
@@ -48,6 +55,7 @@ Short information about what has changed between releases.
 * Improve Notification class which now provides realtime action
 
 ### Release 1.0.2
+
 * Update of okhttp.
 * Better integration-tests.
 * Better login-process (include tenant in username).
@@ -55,6 +63,7 @@ Short information about what has changed between releases.
 * Refactoring.
 
 ### Release 1.0.0
+
 * Improved Examples: Add examples for SDK-Users (see DEVELOPER.md)
 * Implemented Sensor Library
 * Implemented Binaries API
@@ -68,6 +77,7 @@ Short information about what has changed between releases.
 * Provides and uses SmartRequest/-Response classes
 
 ### Release 0.6.0
+
 * Complete Device control
 * Complete Real-time notifications
 * Complete Real-time statements
@@ -79,17 +89,20 @@ Short information about what has changed between releases.
 * Refactor collection classes extending JsonArrayPagination base class
 
 ### Release 0.5.0
+
 * Most important change is the removal of right now unused parameter tenant in CloudOfThingsPlatform constructor ([See commit 62079fe](https://github.com/cloud-of-things/cot-java-rest-sdk/commit/62079feee68dfc371b545cf2ed69fa9f858e5573)).
 * Unsuccessful creation/store of objects in the CoT will now result in a CotSdkException.
 * New method DeviceCredentialsApi.NewDeviceRequest(..).
 * MeasurementsApi supports creating measurement collections.
 
 ### Release 0.4.0
+
 * Improvements, e.g. connection exception handling
 * Short information about what has changed between releases.
 * Bulk Operations (beta)
 
 ### Release 0.3.0
+
 * Complete Inventory
  * Get ManagedObjects in Collection
 * Complete Alarm API
@@ -99,6 +112,7 @@ Short information about what has changed between releases.
 * Complete IdentityApi
 
 ### Release 0.2.0
+
 * Complete Events
 * Complete Device registration process
 * Implement removal of devices and its belongings

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Short information about what has changed between releases.
 
 ### Upcoming Release 1.1.0
 
-* Efficiently iterate over all objects in a collection via Java 8 Stream (accessible via `stream()`): pagination is automatically performed in the background
+* Includes [Pull Request #73](https://github.com/cloud-of-things/cot-java-rest-sdk/pull/73): Efficiently iterate over all objects in a collection via Java 8 Stream (accessible via `stream()`): pagination is automatically performed in the background
 * Resolve [issue #72](https://github.com/cloud-of-things/cot-java-rest-sdk/issues/72): Improved paging performance 
 
 ### Release 1.0.5

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,14 @@
             <artifactId>gson</artifactId>
             <version>2.8.1</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305 -->
+        <!-- Used for @Nullable and @Nonnull annotations. -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmCollection.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Created by Patrick Steinert on 24.11.16.
@@ -14,7 +14,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  * @author Patrick Steinert
  * @since 0.3.0
  */
-public class AlarmCollection extends JsonArrayPagination {
+public class AlarmCollection extends IterableObjectPagination<Alarm> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.alarmCollection+json;charset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "alarms";
@@ -29,12 +29,23 @@ public class AlarmCollection extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      * @param pageSize                max number of retrieved elements per page.
      */
-    AlarmCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-    final String relativeApiUrl,
-    final Gson gson,
-    final Filter.FilterBuilder filterBuilder,
-    final int pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder, pageSize);
+    AlarmCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            jsonAlarm -> new Alarm(gson.fromJson(jsonAlarm, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder,
+            pageSize
+        );
     }
 
     /**
@@ -51,7 +62,7 @@ public class AlarmCollection extends JsonArrayPagination {
             final Alarm[] arrayOfAlarms = new Alarm[jsonAlarms.size()];
             for (int i = 0; i < jsonAlarms.size(); i++) {
                 JsonElement jsonAlarm = jsonAlarms.get(i).getAsJsonObject();
-                final Alarm alarm = new Alarm(gson.fromJson(jsonAlarm, ExtensibleObject.class));
+                final Alarm alarm = objectMapper.apply(jsonAlarm);
                 arrayOfAlarms[i] = alarm;
             }
             return arrayOfAlarms;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/audit/AuditRecordCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/audit/AuditRecordCollection.java
@@ -6,12 +6,12 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Created by Andreas Dyck on 27.07.17.
  */
-public class AuditRecordCollection extends JsonArrayPagination {
+public class AuditRecordCollection extends IterableObjectPagination<AuditRecord> {
 
     private static final String CONTENT_TYPE_COLLECTION = "application/vnd.com.nsn.cumulocity.auditRecordCollection+json;charset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "auditRecords";
@@ -25,11 +25,21 @@ public class AuditRecordCollection extends JsonArrayPagination {
      * @param gson                    the necessary json De-/serializer.
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      */
-    AuditRecordCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                          final String relativeApiUrl,
-                          final Gson gson,
-                          final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, CONTENT_TYPE_COLLECTION, COLLECTION_ELEMENT_NAME, filterBuilder);
+    AuditRecordCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            jsonAuditRecord ->  new AuditRecord(gson.fromJson(jsonAuditRecord, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            CONTENT_TYPE_COLLECTION,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
     /**
@@ -44,7 +54,7 @@ public class AuditRecordCollection extends JsonArrayPagination {
             final AuditRecord[] arrayOfAuditRecords = new AuditRecord[jsonAuditRecords.size()];
             for (int i = 0; i < jsonAuditRecords.size(); i++) {
                 JsonElement jsonAuditRecord = jsonAuditRecords.get(i).getAsJsonObject();
-                final AuditRecord auditRecord = new AuditRecord(gson.fromJson(jsonAuditRecord, ExtensibleObject.class));
+                final AuditRecord auditRecord = objectMapper.apply(jsonAuditRecord);
                 arrayOfAuditRecords[i] = auditRecord;
             }
             return arrayOfAuditRecords;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/devicecontrol/BulkOperationCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/devicecontrol/BulkOperationCollection.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonArray;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Represents a pageable BulkOperation collection.
@@ -18,7 +18,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  * @since 0.6.0
  * Created by Andreas Dyck on 04.09.17.
  */
-public class BulkOperationCollection extends JsonArrayPagination {
+public class BulkOperationCollection extends IterableObjectPagination<BulkOperation> {
 
     private static final String CONTENT_TYPE_BULK_OPERATION_COLLECTION = "application/vnd.com.nsn.cumulocity.bulkOperationCollection+json;charset=UTF-8;ver=0.9";
     private static final String BULK_OPERATION_COLLECTION_ELEMENT_NAME = "bulkOperations";
@@ -33,12 +33,23 @@ public class BulkOperationCollection extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      * @param pageSize                max number of retrieved elements per page.
      */
-    BulkOperationCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                            final String relativeApiUrl,
-                            final Gson gson,
-                            final Filter.FilterBuilder filterBuilder,
-                            final int pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, CONTENT_TYPE_BULK_OPERATION_COLLECTION, BULK_OPERATION_COLLECTION_ELEMENT_NAME, filterBuilder, pageSize);
+    BulkOperationCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            bulkOperationJson -> new BulkOperation(gson.fromJson(bulkOperationJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            CONTENT_TYPE_BULK_OPERATION_COLLECTION,
+            BULK_OPERATION_COLLECTION_ELEMENT_NAME,
+            filterBuilder,
+            pageSize
+        );
     }
 
     /**
@@ -52,7 +63,7 @@ public class BulkOperationCollection extends JsonArrayPagination {
         final JsonArray jsonBulkOperations = getJsonArray();
 
         return (jsonBulkOperations == null) ? new BulkOperation[0] : StreamSupport.stream(jsonBulkOperations.spliterator(), false).
-                map(bulkOperation -> new BulkOperation(gson.fromJson(bulkOperation.getAsJsonObject(), ExtensibleObject.class))).
+                map(objectMapper).
                 toArray(BulkOperation[]::new);
     }
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/devicecontrol/NewDeviceRequestCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/devicecontrol/NewDeviceRequestCollection.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Represents a pageable NewDeviceRequest collection.
@@ -14,7 +14,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  * @since 0.3.0
  * Created by Patrick Steinert on 19.12.16.
  */
-public class NewDeviceRequestCollection extends JsonArrayPagination {
+public class NewDeviceRequestCollection extends IterableObjectPagination<NewDeviceRequest> {
 
     private static final String CONTENT_TYPE_NEW_DEVICE_REQUEST_COLLECTION = "application/vnd.com.nsn.cumulocity.newDeviceRequestCollection+json;charset=UTF-8;ver=0.9";
     private static final String NEW_DEVICE_REQUEST_COLLECTION_ELEMENT_NAME = "newDeviceRequests";
@@ -29,12 +29,23 @@ public class NewDeviceRequestCollection extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      * @param pageSize                max number of retrieved elements per page.
      */
-    NewDeviceRequestCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                    final String relativeApiUrl,
-                    final Gson gson,
-                    final Filter.FilterBuilder filterBuilder,
-                    final int pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, CONTENT_TYPE_NEW_DEVICE_REQUEST_COLLECTION, NEW_DEVICE_REQUEST_COLLECTION_ELEMENT_NAME, filterBuilder, pageSize);
+    NewDeviceRequestCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            newDeviceRequestJson -> new NewDeviceRequest(gson.fromJson(newDeviceRequestJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            CONTENT_TYPE_NEW_DEVICE_REQUEST_COLLECTION,
+            NEW_DEVICE_REQUEST_COLLECTION_ELEMENT_NAME,
+            filterBuilder,
+            pageSize
+        );
     }
 
     /**
@@ -51,7 +62,7 @@ public class NewDeviceRequestCollection extends JsonArrayPagination {
             final NewDeviceRequest[] arrayOfNewDeviceRequests = new NewDeviceRequest[jsonNewDeviceRequests.size()];
             for (int i = 0; i < jsonNewDeviceRequests.size(); i++) {
                 JsonElement jsonNewDeviceRequest = jsonNewDeviceRequests.get(i).getAsJsonObject();
-                final NewDeviceRequest newDeviceRequest = new NewDeviceRequest(gson.fromJson(jsonNewDeviceRequest, ExtensibleObject.class));
+                final NewDeviceRequest newDeviceRequest =objectMapper.apply(jsonNewDeviceRequest);
                 arrayOfNewDeviceRequests[i] = newDeviceRequest;
             }
             return arrayOfNewDeviceRequests;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/devicecontrol/OperationCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/devicecontrol/OperationCollection.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonArray;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Represents a pageable Operation collection.
@@ -18,7 +18,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  * @since 0.1.0
  * Created by Patrick Steinert on 14.02.16.
  */
-public class OperationCollection  extends JsonArrayPagination {
+public class OperationCollection  extends IterableObjectPagination<Operation> {
 
     private static final String CONTENT_TYPE_OPERATION_COLLECTION = "application/vnd.com.nsn.cumulocity.operationCollection+json;charset=UTF-8;ver=0.9";
     private static final String OPERATION_COLLECTION_ELEMENT_NAME = "operations";
@@ -33,12 +33,23 @@ public class OperationCollection  extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      * @param pageSize                max number of retrieved elements per page.
      */
-    OperationCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                    final String relativeApiUrl,
-                    final Gson gson,
-                    final Filter.FilterBuilder filterBuilder,
-                    final int pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, CONTENT_TYPE_OPERATION_COLLECTION, OPERATION_COLLECTION_ELEMENT_NAME, filterBuilder, pageSize);
+    OperationCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            operationJson -> new Operation(gson.fromJson(operationJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            CONTENT_TYPE_OPERATION_COLLECTION,
+            OPERATION_COLLECTION_ELEMENT_NAME,
+            filterBuilder,
+            pageSize
+        );
     }
 
     /**
@@ -52,7 +63,7 @@ public class OperationCollection  extends JsonArrayPagination {
         final JsonArray jsonOperations = getJsonArray();
 
         return (jsonOperations == null) ? new Operation[0] : StreamSupport.stream(jsonOperations.spliterator(), false).
-                map(operation -> new Operation(gson.fromJson(operation.getAsJsonObject(), ExtensibleObject.class))).
+                map(objectMapper).
                 toArray(Operation[]::new);
     }
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/event/EventCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/event/EventCollection.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package com.telekom.m2m.cot.restsdk.event;
 
 import com.google.gson.Gson;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/event/EventCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/event/EventCollection.java
@@ -9,13 +9,13 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * @author chuhlich
  *
  */
-public class EventCollection extends JsonArrayPagination {
+public class EventCollection extends IterableObjectPagination<Event> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.eventCollection+json;charset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "events";
@@ -29,11 +29,21 @@ public class EventCollection extends JsonArrayPagination {
      * @param gson                    the necessary json De-/serializer.
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      */
-    EventCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                    final String relativeApiUrl,
-                    final Gson gson,
-                    final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder);
+    EventCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            eventJson -> new Event(gson.fromJson(eventJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
     /**
@@ -50,7 +60,7 @@ public class EventCollection extends JsonArrayPagination {
             final Event[] arrayOfEvents = new Event[jsonEvents.size()];
             for (int i = 0; i < jsonEvents.size(); i++) {
                 JsonElement jsonEvent = jsonEvents.get(i).getAsJsonObject();
-                final Event event = new Event(gson.fromJson(jsonEvent, ExtensibleObject.class));
+                final Event event = objectMapper.apply(jsonEvent);
                 arrayOfEvents[i] = event;
             }
             return arrayOfEvents;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/identity/ExternalIdCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/identity/ExternalIdCollection.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Represents a pageable ExternalId collection.
@@ -13,7 +13,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  * @since 0.3.0
  * Created by Patrick Steinert on 19.12.16.
  */
-public class ExternalIdCollection extends JsonArrayPagination {
+public class ExternalIdCollection extends IterableObjectPagination<ExternalId> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.externalIdCollection+json;charset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "externalIds";
@@ -28,12 +28,23 @@ public class ExternalIdCollection extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      * @param pageSize                max number of retrieved elements per page.
      */
-    ExternalIdCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                    final String relativeApiUrl,
-                    final Gson gson,
-                    final Filter.FilterBuilder filterBuilder,
-                    final int pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder, pageSize);
+    ExternalIdCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            externalIdJson -> gson.fromJson(externalIdJson, ExternalId.class),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder,
+            pageSize
+        );
     }
 
     /**
@@ -50,7 +61,7 @@ public class ExternalIdCollection extends JsonArrayPagination {
             final ExternalId[] arrayOfExternalIds = new ExternalId[jsonExternalIds.size()];
             for (int i = 0; i < jsonExternalIds.size(); i++) {
                 JsonElement jsonExternalId = jsonExternalIds.get(i).getAsJsonObject();
-                final ExternalId externalId = gson.fromJson(jsonExternalId, ExternalId.class);
+                final ExternalId externalId = objectMapper.apply(jsonExternalId);
                 arrayOfExternalIds[i] = externalId;
             }
             return arrayOfExternalIds;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
@@ -46,8 +46,7 @@ public class BinariesCollection extends IterableObjectPagination<Binary> {
      */
     public Binary[] getBinaries() {
         final JsonArray jsonBinaries = getJsonArray();
-        Binary[] binaries = gson.fromJson(jsonBinaries, Binary[].class);
-        return binaries;
+        return gson.fromJson(jsonBinaries, Binary[].class);
     }
 
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/BinariesCollection.java
@@ -4,28 +4,39 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
-
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * A Collection of binaries, or, rather, their metadata.
  */
-public class BinariesCollection extends JsonArrayPagination {
+public class BinariesCollection extends IterableObjectPagination<Binary> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.applicationCollection+json;vcharset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "managedObjects";
 
 
+    public BinariesCollection(
+        Filter.FilterBuilder filters,
+        CloudOfThingsRestClient cloudOfThingsRestClient,
+        String relativeApiUrl,
+        Gson gson,
+        Integer pageSize
+    ) {
+        super(
+            binaryJson -> gson.fromJson(binaryJson, Binary.class),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filters
+        );
+        if (pageSize != null) {
+            setPageSize(pageSize);
+        }
+    }
 
-	public BinariesCollection(Filter.FilterBuilder filters, CloudOfThingsRestClient cloudOfThingsRestClient,
-			String relativeApiUrl, Gson gson, Integer pageSize) {
-		super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filters);
-		if (pageSize != null) {
-			setPageSize(pageSize);
-		}
-	}
-    
-    
+
     /**
      * Retrieves the current page.
      * <p>

--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/ManagedObjectCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/ManagedObjectCollection.java
@@ -58,9 +58,7 @@ public class ManagedObjectCollection extends IterableObjectPagination<ManagedObj
      */
     public ManagedObject[] getManagedObjects() {
         final JsonArray jsonManagedObjects = getJsonArray();
-        ManagedObject[] managedObjects = gson.fromJson(jsonManagedObjects, ManagedObject[].class);
-
-        return managedObjects;
+        return gson.fromJson(jsonManagedObjects, ManagedObject[].class);
     }
     
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/inventory/ManagedObjectCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/inventory/ManagedObjectCollection.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Represents a pageable ManagedObject collection.
@@ -15,7 +15,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  *
  * @since 0.3.0
  */
-public class ManagedObjectCollection extends JsonArrayPagination {
+public class ManagedObjectCollection extends IterableObjectPagination<ManagedObject> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.managedObjectCollection+json;charset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "managedObjects";
@@ -30,12 +30,23 @@ public class ManagedObjectCollection extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      * @param pageSize                max number of retrieved elements per page.
      */
-    ManagedObjectCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                         final String relativeApiUrl,
-                         final Gson gson,
-                         final Filter.FilterBuilder filterBuilder,
-                         final int pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder, pageSize);
+    ManagedObjectCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            managedObjectJson -> gson.fromJson(managedObjectJson, ManagedObject.class),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder,
+            pageSize
+        );
     }
 
     /**

--- a/src/main/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementCollection.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Represents a pageable Measurement collection.
@@ -17,7 +17,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  * @since 0.1.0
  * Created by Patrick Steinert on 14.02.16.
  */
-public class MeasurementCollection extends JsonArrayPagination {
+public class MeasurementCollection extends IterableObjectPagination<Measurement> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.measurementCollection+json;charset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "measurements";
@@ -32,12 +32,23 @@ public class MeasurementCollection extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      * @param pageSize                max number of retrieved elements per page.
      */
-    MeasurementCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                         final String relativeApiUrl,
-                         final Gson gson,
-                         final Filter.FilterBuilder filterBuilder,
-                         final int pageSize) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder, pageSize);
+    MeasurementCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            measurementJson -> new Measurement(gson.fromJson(measurementJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder,
+            pageSize
+        );
     }
 
     /**
@@ -54,7 +65,7 @@ public class MeasurementCollection extends JsonArrayPagination {
             final Measurement[] arrayOfMeasurements = new Measurement[jsonMeasurements.size()];
             for (int i = 0; i < jsonMeasurements.size(); i++) {
                 JsonElement jsonMeasurement = jsonMeasurements.get(i).getAsJsonObject();
-                final Measurement measurement = new Measurement(gson.fromJson(jsonMeasurement, ExtensibleObject.class));
+                final Measurement measurement =objectMapper.apply(jsonMeasurement);
                 arrayOfMeasurements[i] = measurement;
             }
             return arrayOfMeasurements;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/realtime/ModuleCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/realtime/ModuleCollection.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * This class represents a collection of {@link Module}s.
@@ -12,7 +12,7 @@ import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
  * Created by Ozan Arslan on 14.08.2017.
  *
  */
-public class ModuleCollection extends JsonArrayPagination {
+public class ModuleCollection extends IterableObjectPagination<Module> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.cepModuleCollection+json;ver=0.9";
 
@@ -27,11 +27,21 @@ public class ModuleCollection extends JsonArrayPagination {
      * @param gson                    the necessary json De-/serializer.
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      */
-    ModuleCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                     final String relativeApiUrl,
-                     final Gson gson,
-                     final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder);
+    ModuleCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            moduleJson -> gson.fromJson(moduleJson, Module.class),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
     /**
@@ -45,7 +55,7 @@ public class ModuleCollection extends JsonArrayPagination {
         if (jsonModules != null) {
             final Module[] arrayOfModules = new Module[jsonModules.size()];
             for (int i = 0; i < arrayOfModules.length; i++) {
-                arrayOfModules[i] = gson.fromJson(jsonModules.get(i), Module.class);
+                arrayOfModules[i] = objectMapper.apply(jsonModules.get(i));
             }
             return arrayOfModules;
         } else {

--- a/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/retentionrule/RetentionRuleCollection.java
@@ -7,10 +7,9 @@ import com.google.gson.JsonArray;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
-
-public class RetentionRuleCollection extends JsonArrayPagination {
+public class RetentionRuleCollection extends IterableObjectPagination<RetentionRule> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.retentionRuleCollection+json;charset=UTF-8;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "retentionRules";
@@ -25,11 +24,21 @@ public class RetentionRuleCollection extends JsonArrayPagination {
      * @param gson                    the necessary json De-/serializer.
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      */
-    RetentionRuleCollection(final CloudOfThingsRestClient cloudOfThingsRestClient,
-                            final String relativeApiUrl,
-                            final Gson gson,
-                            final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME, filterBuilder);
+    RetentionRuleCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            ruleJson ->  new RetentionRule(gson.fromJson(ruleJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
 
@@ -43,7 +52,7 @@ public class RetentionRuleCollection extends JsonArrayPagination {
     public RetentionRule[] getRetentionRules() {
         final JsonArray jsonRules = getJsonArray();
         return (jsonRules == null) ? new RetentionRule[0] : StreamSupport.stream(jsonRules.spliterator(), false).
-                map(rule -> new RetentionRule(gson.fromJson(rule.getAsJsonObject(), ExtensibleObject.class))).
+                map(objectMapper).
                 toArray(RetentionRule[]::new);
     }
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/users/GroupCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/users/GroupCollection.java
@@ -6,15 +6,14 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
-
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Class that defines the methods of group collection. Group collections are
  * objects that hold several groups. They define methods on a collection of
  * groups.Created by Ozan Arslan on 13.07.2017
  */
-public class GroupCollection extends JsonArrayPagination {
+public class GroupCollection extends IterableObjectPagination<Group> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.groupCollection+json;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "groups";
@@ -31,10 +30,21 @@ public class GroupCollection extends JsonArrayPagination {
      * @param filterBuilder
      *            the build criteria or null if all items should be retrieved.
      */
-    GroupCollection(final CloudOfThingsRestClient cloudOfThingsRestClient, final String relativeApiUrl, final Gson gson,
-            final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME,
-                filterBuilder);
+    GroupCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            groupJson -> new Group(gson.fromJson(groupJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
     /**
@@ -48,8 +58,8 @@ public class GroupCollection extends JsonArrayPagination {
         if (jsonGroups != null) {
             final Group[] arrayOfGroups = new Group[jsonGroups.size()];
             for (int i = 0; i < jsonGroups.size(); i++) {
-                JsonElement jsonGroup = jsonGroups.get(i).getAsJsonObject();
-                final Group group = new Group(gson.fromJson(jsonGroup, ExtensibleObject.class));
+                JsonElement jsonGroup = jsonGroups.get(i);
+                final Group group = objectMapper.apply(jsonGroup);
                 arrayOfGroups[i] = group;
             }
             return arrayOfGroups;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/users/GroupReferenceCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/users/GroupReferenceCollection.java
@@ -6,13 +6,13 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * The class that defines the methods on a collection of group references.
  * Created by Ozan Arslan on 27.07.2017
  */
-public class GroupReferenceCollection extends JsonArrayPagination {
+public class GroupReferenceCollection extends IterableObjectPagination<GroupReference> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.groupReferenceCollection+json;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "references";
@@ -29,10 +29,21 @@ public class GroupReferenceCollection extends JsonArrayPagination {
      * @param filterBuilder
      *            the build criteria or null if all items should be retrieved.
      */
-    GroupReferenceCollection(final CloudOfThingsRestClient cloudOfThingsRestClient, final String relativeApiUrl,
-            final Gson gson, final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME,
-                filterBuilder);
+    GroupReferenceCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            groupReferenceJson -> new GroupReference(gson.fromJson(groupReferenceJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
     /**
@@ -46,9 +57,8 @@ public class GroupReferenceCollection extends JsonArrayPagination {
         if (jsonGroupReferences != null) {
             final GroupReference[] arrayOfGroupReferences = new GroupReference[jsonGroupReferences.size()];
             for (int i = 0; i < jsonGroupReferences.size(); i++) {
-                JsonElement jsonGroup = jsonGroupReferences.get(i).getAsJsonObject();
-                final GroupReference groupReference = new GroupReference(
-                        gson.fromJson(jsonGroup, ExtensibleObject.class));
+                JsonElement jsonGroup = jsonGroupReferences.get(i);
+                final GroupReference groupReference = objectMapper.apply(jsonGroup);
                 arrayOfGroupReferences[i] = groupReference;
             }
             return arrayOfGroupReferences;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/users/RoleCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/users/RoleCollection.java
@@ -6,14 +6,13 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
-
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * Class that defines the methods of role collection. A role collection is a
  * group of roles. Created by Ozan Arslan on 13.07.2017
  */
-public class RoleCollection extends JsonArrayPagination {
+public class RoleCollection extends IterableObjectPagination<Role> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.roleCollection+json;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "roles";
@@ -30,10 +29,21 @@ public class RoleCollection extends JsonArrayPagination {
      * @param filterBuilder
      *            the build criteria or null if all items should be retrieved.
      */
-    RoleCollection(final CloudOfThingsRestClient cloudOfThingsRestClient, final String relativeApiUrl, final Gson gson,
-            final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME,
-                filterBuilder);
+    RoleCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            roleJson -> new Role(gson.fromJson(roleJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
     /**
@@ -48,7 +58,7 @@ public class RoleCollection extends JsonArrayPagination {
             final Role[] arrayOfRoles = new Role[jsonRoles.size()];
             for (int i = 0; i < jsonRoles.size(); i++) {
                 JsonElement jsonRole = jsonRoles.get(i).getAsJsonObject();
-                final Role role = new Role(gson.fromJson(jsonRole, ExtensibleObject.class));
+                final Role role = objectMapper.apply(jsonRole);
                 arrayOfRoles[i] = role;
             }
             return arrayOfRoles;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/users/RoleReferenceCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/users/RoleReferenceCollection.java
@@ -6,15 +6,14 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
-
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * The class that defines methods related to the role reference collections.
  * Role reference collections are a group of references to the roles. Created by
  * Ozan Arslan on 27.07.2017
  */
-public class RoleReferenceCollection extends JsonArrayPagination {
+public class RoleReferenceCollection extends IterableObjectPagination<RoleReference> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.roleReferenceCollection+json;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "references";
@@ -31,10 +30,21 @@ public class RoleReferenceCollection extends JsonArrayPagination {
      * @param filterBuilder
      *            the build criteria or null if all items should be retrieved.
      */
-    RoleReferenceCollection(final CloudOfThingsRestClient cloudOfThingsRestClient, final String relativeApiUrl,
-            final Gson gson, final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME,
-                filterBuilder);
+    RoleReferenceCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            roleReferenceJson -> new RoleReference(gson.fromJson(roleReferenceJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
     /**
@@ -49,7 +59,7 @@ public class RoleReferenceCollection extends JsonArrayPagination {
             final RoleReference[] arrayOfRoleReferences = new RoleReference[jsonRoleReferences.size()];
             for (int i = 0; i < jsonRoleReferences.size(); i++) {
                 JsonElement jsonRole = jsonRoleReferences.get(i).getAsJsonObject();
-                final RoleReference rolereference = new RoleReference(gson.fromJson(jsonRole, ExtensibleObject.class));
+                final RoleReference rolereference = objectMapper.apply(jsonRole);
                 arrayOfRoleReferences[i] = rolereference;
             }
             return arrayOfRoleReferences;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/users/UserReferenceCollection.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/users/UserReferenceCollection.java
@@ -6,14 +6,13 @@ import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
-import com.telekom.m2m.cot.restsdk.util.JsonArrayPagination;
-
+import com.telekom.m2m.cot.restsdk.util.IterableObjectPagination;
 
 /**
  * The class that defines the operations on a collection of user references.
  * Created by Ozan Arslan on 27.07.2017
  */
-public class UserReferenceCollection extends JsonArrayPagination {
+public class UserReferenceCollection extends IterableObjectPagination<UserReference> {
 
     private static final String COLLECTION_CONTENT_TYPE = "application/vnd.com.nsn.cumulocity.userReferenceCollection+json;ver=0.9";
     private static final String COLLECTION_ELEMENT_NAME = "references";
@@ -31,10 +30,21 @@ public class UserReferenceCollection extends JsonArrayPagination {
      * @param filterBuilder
      *            the build criteria or null if all items should be retrieved.
      */
-    UserReferenceCollection(final CloudOfThingsRestClient cloudOfThingsRestClient, final String relativeApiUrl,
-            final Gson gson, final Filter.FilterBuilder filterBuilder) {
-        super(cloudOfThingsRestClient, relativeApiUrl, gson, COLLECTION_CONTENT_TYPE, COLLECTION_ELEMENT_NAME,
-                filterBuilder);
+    UserReferenceCollection(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            userReferenceJson -> new UserReference(gson.fromJson(userReferenceJson, ExtensibleObject.class)),
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            COLLECTION_CONTENT_TYPE,
+            COLLECTION_ELEMENT_NAME,
+            filterBuilder
+        );
     }
 
 
@@ -49,8 +59,8 @@ public class UserReferenceCollection extends JsonArrayPagination {
         if (jsonUserReferences != null) {
             final UserReference[] arrayOfUserReferences = new UserReference[jsonUserReferences.size()];
             for (int i = 0; i < jsonUserReferences.size(); i++) {
-                JsonElement jsonGroup = jsonUserReferences.get(i).getAsJsonObject();
-                final UserReference userreference = new UserReference(gson.fromJson(jsonGroup, ExtensibleObject.class));
+                JsonElement jsonGroup = jsonUserReferences.get(i);
+                final UserReference userreference = objectMapper.apply(jsonGroup);
                 arrayOfUserReferences[i] = userreference;
             }
             return arrayOfUserReferences;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
@@ -121,7 +121,7 @@ abstract public class IterableObjectPagination<T> extends JsonArrayPagination {
 
     @Nonnull
     private Iterator<JsonArray> createPageIterator() {
-        final IterableObjectPagination<T> pagination = this;
+        final JsonArrayPagination pagination = this.copy();
         return new Iterator<JsonArray>() {
             /**
              * Indicates if another item page is available.

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
@@ -1,0 +1,67 @@
+package com.telekom.m2m.cot.restsdk.util;
+
+import com.google.gson.Gson;
+import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+
+import java.util.Objects;
+
+public class IterableObjectPagination<T> extends JsonArrayPagination {
+    /**
+     * Creates a pagination with default page size.
+     *
+     * @param cloudOfThingsRestClient the necessary REST client to send requests to the CoT.
+     * @param relativeApiUrl          relative url of the REST API without leading slash.
+     * @param gson                    the necessary json De-/serializer.
+     * @param contentType             the Content-Type of the JSON Object.
+     * @param collectionElementName   json element name which contains an array of JSON Objects.
+     * @param filterBuilder           the build criteria or null if all items should be retrieved.
+     */
+    public IterableObjectPagination(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final String contentType,
+        final String collectionElementName,
+        final Filter.FilterBuilder filterBuilder
+    ) {
+        super(
+            Objects.requireNonNull(cloudOfThingsRestClient),
+            Objects.requireNonNull(relativeApiUrl),
+            Objects.requireNonNull(gson),
+            Objects.requireNonNull(contentType),
+            Objects.requireNonNull(collectionElementName),
+            Objects.requireNonNull(filterBuilder)
+        );
+    }
+
+    /**
+     * Creates a pagination with custom page size.
+     *
+     * @param cloudOfThingsRestClient the necessary REST client to send requests to the CoT.
+     * @param relativeApiUrl          relative url of the REST API without leading slash.
+     * @param gson                    the necessary json De-/serializer.
+     * @param contentType             the Content-Type of the JSON Object.
+     * @param collectionElementName   json element name which contains an array of JSON Objects.
+     * @param filterBuilder           the build criteria or null if all items should be retrieved.
+     * @param pageSize                max number of retrieved elements per page.
+     */
+    public IterableObjectPagination(
+        final CloudOfThingsRestClient cloudOfThingsRestClient,
+        final String relativeApiUrl,
+        final Gson gson,
+        final String contentType,
+        final String collectionElementName,
+        final Filter.FilterBuilder filterBuilder,
+        final int pageSize
+    ) {
+        super(
+            Objects.requireNonNull(cloudOfThingsRestClient),
+            Objects.requireNonNull(relativeApiUrl),
+            Objects.requireNonNull(gson),
+            Objects.requireNonNull(contentType),
+            Objects.requireNonNull(collectionElementName),
+            Objects.requireNonNull(filterBuilder),
+            pageSize
+        );
+    }
+}

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
@@ -1,13 +1,25 @@
 package com.telekom.m2m.cot.restsdk.util;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.stream.Stream;
 
-public class IterableObjectPagination<T> extends JsonArrayPagination {
+/**
+ * Simplifies iteration over paged result by providing access to paged objects
+ * via {@link Stream}.
+ *
+ * The object stream can be accessed via {@link #stream()}. It will read pages
+ * *only* if necessary and forward until the end of result (the last page) is
+ * reached.
+ *
+ * @param <T> The type of objects on the pages.
+ */
+abstract public class IterableObjectPagination<T> extends JsonArrayPagination {
     /**
      * Creates a pagination with default page size.
      *
@@ -66,4 +78,18 @@ public class IterableObjectPagination<T> extends JsonArrayPagination {
             pageSize
         );
     }
+
+    @Nonnull
+    public Stream<T> stream() {
+        return null;
+    }
+
+    /**
+     * Converts the given JSON data into an object.
+     *
+     * @param element The element.
+     * @return An object created from the JSON data.
+     */
+    @Nonnull
+    abstract protected T convertJsonToObject(@Nonnull final JsonElement element);
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
@@ -79,6 +79,13 @@ abstract public class IterableObjectPagination<T> extends JsonArrayPagination {
         );
     }
 
+    /**
+     * Returns a {@link Stream} that reads objects until the last page is reached.
+     *
+     * The stream can be used only *once* for iteration.
+     *
+     * @return Object stream.
+     */
     @Nonnull
     public Stream<T> stream() {
         return null;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
@@ -114,14 +114,8 @@ public class IterableObjectPagination<T> extends JsonArrayPagination {
             ),
             false
         )
-            .peek(page -> {
-                int x = 1;
-            })
             .flatMap(jsonArray -> StreamSupport.stream(jsonArray.spliterator(), false))
-            .map(this.objectMapper)
-            .peek(item -> {
-                int x = 1;
-            });
+            .map(this.objectMapper);
     }
 
     @Nonnull

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
@@ -3,6 +3,8 @@ package com.telekom.m2m.cot.restsdk.util;
 import com.google.gson.Gson;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 public class IterableObjectPagination<T> extends JsonArrayPagination {
@@ -17,12 +19,12 @@ public class IterableObjectPagination<T> extends JsonArrayPagination {
      * @param filterBuilder           the build criteria or null if all items should be retrieved.
      */
     public IterableObjectPagination(
-        final CloudOfThingsRestClient cloudOfThingsRestClient,
-        final String relativeApiUrl,
-        final Gson gson,
-        final String contentType,
-        final String collectionElementName,
-        final Filter.FilterBuilder filterBuilder
+        @Nonnull final CloudOfThingsRestClient cloudOfThingsRestClient,
+        @Nonnull final String relativeApiUrl,
+        @Nonnull final Gson gson,
+        @Nonnull final String contentType,
+        @Nonnull final String collectionElementName,
+        @Nullable final Filter.FilterBuilder filterBuilder
     ) {
         super(
             Objects.requireNonNull(cloudOfThingsRestClient),
@@ -30,7 +32,7 @@ public class IterableObjectPagination<T> extends JsonArrayPagination {
             Objects.requireNonNull(gson),
             Objects.requireNonNull(contentType),
             Objects.requireNonNull(collectionElementName),
-            Objects.requireNonNull(filterBuilder)
+            filterBuilder
         );
     }
 
@@ -46,12 +48,12 @@ public class IterableObjectPagination<T> extends JsonArrayPagination {
      * @param pageSize                max number of retrieved elements per page.
      */
     public IterableObjectPagination(
-        final CloudOfThingsRestClient cloudOfThingsRestClient,
-        final String relativeApiUrl,
-        final Gson gson,
-        final String contentType,
-        final String collectionElementName,
-        final Filter.FilterBuilder filterBuilder,
+        @Nonnull final CloudOfThingsRestClient cloudOfThingsRestClient,
+        @Nonnull final String relativeApiUrl,
+        @Nonnull final Gson gson,
+        @Nonnull final String contentType,
+        @Nonnull final String collectionElementName,
+        @Nullable final Filter.FilterBuilder filterBuilder,
         final int pageSize
     ) {
         super(
@@ -60,7 +62,7 @@ public class IterableObjectPagination<T> extends JsonArrayPagination {
             Objects.requireNonNull(gson),
             Objects.requireNonNull(contentType),
             Objects.requireNonNull(collectionElementName),
-            Objects.requireNonNull(filterBuilder),
+            filterBuilder,
             pageSize
         );
     }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPagination.java
@@ -28,7 +28,7 @@ public class IterableObjectPagination<T> extends JsonArrayPagination {
      * Converts JSON objects into the object that are provided during iteration.
      */
     @Nonnull
-    private final Function<JsonElement, T> objectMapper;
+    protected final Function<JsonElement, T> objectMapper;
 
     /**
      * Creates a pagination with default page size.

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -21,7 +21,7 @@ public class JsonArrayPagination {
     private int pageCursor = 1;
     private boolean nextAvailable = false;
     private boolean previousAvailable = false;
-    private int pageSize = 5;
+    private int pageSize = DEFAULT_PAGE_SIZE;
 
     private Filter.FilterBuilder criteria = null;
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -158,7 +158,7 @@ public class JsonArrayPagination {
             return false;
         }
         final JsonObject pageStats = page.get("statistics").getAsJsonObject();
-        if (pageStats.has("totalPages")) {
+        if (pageStats.has("totalPages") && !pageStats.get("totalPages").isJsonNull()) {
             // The whole number of pages is known. Check if there is a next page.
             return pageStats.get("currentPage").getAsInt() < pageStats.get("totalPages").getAsInt();
         }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -31,7 +31,7 @@ public class JsonArrayPagination {
     /**
      * The cached response of the current page.
      *
-     * Null if the page has not been requested yet.
+     * Null if the page has not been requested yet or after switching pages via {@link #next()} or {@link #previous()}.
      */
     @Nullable
     private JsonObject currentPageContent = null;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -210,7 +210,7 @@ public class JsonArrayPagination {
      */
     @Nonnull
     protected JsonArrayPagination copy() {
-        return new JsonArrayPagination(
+        final JsonArrayPagination pagination = new JsonArrayPagination(
             cloudOfThingsRestClient,
             relativeApiUrl,
             gson,
@@ -219,6 +219,8 @@ public class JsonArrayPagination {
             criteria,
             pageSize
         );
+        pagination.pageCursor = pageCursor;
+        return pagination;
     }
 
     /**

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -22,7 +22,6 @@ public class JsonArrayPagination {
     private final String collectionElementName;
 
     private int pageCursor = 1;
-    private boolean previousAvailable = false;
     private int pageSize = DEFAULT_PAGE_SIZE;
 
     private Filter.FilterBuilder criteria = null;
@@ -100,8 +99,6 @@ public class JsonArrayPagination {
     @Nullable
     public JsonArray getJsonArray() {
         final JsonObject currentPage = getCurrentPage();
-
-        previousAvailable = currentPage.has("prev");
 
         if (currentPage.has(collectionElementName)) {
             return currentPage.get(collectionElementName).getAsJsonArray();
@@ -182,10 +179,10 @@ public class JsonArrayPagination {
     /**
      * Checks if there is a previous page.
      *
-     * @return true if next page has audit records, otherwise false.
+     * @return true if there is a previous page.
      */
     public boolean hasPrevious() {
-        return previousAvailable;
+        return pageCursor > 1;
     }
 
     /**

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -14,6 +14,7 @@ public class JsonArrayPagination {
 
     private final CloudOfThingsRestClient cloudOfThingsRestClient;
     private final String relativeApiUrl;
+    @Deprecated
     private final String contentType;
     private final String collectionElementName;
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -124,6 +124,11 @@ public class JsonArrayPagination {
 
     /**
      * Moves cursor to the next page.
+     *
+     * Please note: When calling next(), but there is no next page,
+     * then the behavior is undefined.
+     * Use {@link #hasNext()} to check page availability before
+     * calling next().
      */
     public void next() {
         pageCursor += 1;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -22,7 +22,6 @@ public class JsonArrayPagination {
     private final String collectionElementName;
 
     private int pageCursor = 1;
-    private boolean nextAvailable = false;
     private boolean previousAvailable = false;
     private int pageSize = DEFAULT_PAGE_SIZE;
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -177,7 +177,7 @@ public class JsonArrayPagination {
      * @return A copy of this pagination in its current state.
      */
     @Nonnull
-    public JsonArrayPagination copy() {
+    protected JsonArrayPagination copy() {
         return new JsonArrayPagination(
             cloudOfThingsRestClient,
             relativeApiUrl,

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -105,7 +105,6 @@ public class JsonArrayPagination {
 
     @Nonnull
     private JsonObject getJsonObject(final int page) {
-        final String response;
         String url = relativeApiUrl +
                 "?currentPage=" + page +
                 "&pageSize=" + pageSize;
@@ -114,7 +113,7 @@ public class JsonArrayPagination {
         if (criteria != null) {
             url += "&" + criteria.buildFilter();
         }
-        response = cloudOfThingsRestClient.getResponse(url);
+        final String response = cloudOfThingsRestClient.getResponse(url);
 
         return gson.fromJson(response, JsonObject.class);
     }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -173,4 +173,20 @@ public class JsonArrayPagination {
             this.pageSize = DEFAULT_PAGE_SIZE;
         }
     }
+
+    /**
+     * @return A copy of this pagination in its current state.
+     */
+    @Nonnull
+    public JsonArrayPagination copy() {
+        return new JsonArrayPagination(
+            cloudOfThingsRestClient,
+            relativeApiUrl,
+            gson,
+            contentType,
+            collectionElementName,
+            criteria,
+            pageSize
+        );
+    }
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -102,6 +103,7 @@ public class JsonArrayPagination {
         }
     }
 
+    @Nonnull
     private JsonObject getJsonObject(final int page) {
         final String response;
         String url = relativeApiUrl +

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPagination.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 
+import javax.annotation.Nullable;
+
 /**
  * Created by Andreas Dyck on 26.07.17.
  */
@@ -87,6 +89,7 @@ public class JsonArrayPagination {
      *
      * @return JsonArray of found JsonElements
      */
+    @Nullable
     public JsonArray getJsonArray() {
         final JsonObject object = getJsonObject(pageCursor);
 

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -3,7 +3,7 @@ package com.telekom.m2m.cot.restsdk.util;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
@@ -36,7 +36,7 @@ public class IterableObjectPaginationTest {
      */
     private CloudOfThingsRestClient cloudOfThingsRestClient;
 
-    @BeforeTest
+    @BeforeMethod
     public void setup() {
         cloudOfThingsRestClient = createRestClient();
         pagination = new IterableObjectPagination<ExtensibleObject>(

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -14,10 +14,12 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 
 public class IterableObjectPaginationTest {
@@ -61,6 +63,18 @@ public class IterableObjectPaginationTest {
         final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
 
         assertEquals(objects.size(), 10);
+    }
+
+    @Test
+    public void streamReturnsDifferentObjectsOnEachCall() {
+        simulateNumberOfObjectsOnPages(10);
+
+        try (
+            final Stream<ExtensibleObject> first = pagination.stream();
+            final Stream<ExtensibleObject> second = pagination.stream()
+        ) {
+            assertNotSame(first, second);
+        }
     }
 
     @Test

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -126,6 +126,18 @@ public class IterableObjectPaginationTest {
         assertEquals(objects.size(), 0);
     }
 
+    @Test
+    public void startsStreamingFromCurrentPage() {
+        simulateNumberOfObjectsOnPages(10);
+
+        // Skip one page...
+        pagination.next();
+        // ... and start streaming objects from page 2.
+        final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
+
+        assertEquals(objects.size(), 10 - PAGE_SIZE_IN_TESTS);
+    }
+
     private void simulateNumberOfObjectsOnPages(final int numberOfObjects) {
         if (numberOfObjects == 0) {
             simulatePageResponse(1, readTemplate("pages/no-filter/empty-page.json"));

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -64,6 +64,16 @@ public class IterableObjectPaginationTest {
     }
 
     @Test
+    public void multipleStreamCallsReturnSameNumberOfObjects() {
+        simulateNumberOfObjectsOnPages(10);
+
+        final List<ExtensibleObject> first = pagination.stream().collect(Collectors.toList());
+        final List<ExtensibleObject> second = pagination.stream().collect(Collectors.toList());
+
+        assertEquals(first.size(), second.size());
+    }
+
+    @Test
     public void streamReadsObjectsIfThereIsOnlyOnePage() {
         simulateNumberOfObjectsOnPages(2);
 

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -115,7 +115,7 @@ public class IterableObjectPaginationTest {
         final int totalPages = ceilDiv(numberOfObjects, PAGE_SIZE_IN_TESTS);
         for (int page = 1; page <= totalPages; page++) {
             final int itemsOnPage = (page == totalPages) ? numberOfObjects % PAGE_SIZE_IN_TESTS : PAGE_SIZE_IN_TESTS;
-            final String itemsJson = IntStream.range(1, itemsOnPage)
+            final String itemsJson = IntStream.range(1, itemsOnPage + 1)
                 .mapToObj(id -> itemTemplate.replace("%%id%%", String.valueOf(id)))
                 .collect(Collectors.joining(","));
             final String body = pageTemplate

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -36,7 +36,7 @@ public class IterableObjectPaginationTest {
 
     @BeforeTest
     public void setup() {
-        cloudOfThingsRestClient = mock(CloudOfThingsRestClient.class);
+        cloudOfThingsRestClient = createRestClient();
         pagination = new IterableObjectPagination<ExtensibleObject>(
             cloudOfThingsRestClient,
             "test/url",
@@ -60,7 +60,7 @@ public class IterableObjectPaginationTest {
 
         final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
 
-        assertEquals( objects.size(), 10);
+        assertEquals(objects.size(), 10);
     }
 
     @Test
@@ -186,5 +186,21 @@ public class IterableObjectPaginationTest {
 
     private int ceilDiv(final int dividend, final int divisor){
         return -Math.floorDiv(-dividend,divisor);
+    }
+
+    /**
+     * Creates a mocked test client.
+     *
+     * The client returns empty responses per default.
+     *
+     * @return The mocked test client.
+     */
+    @Nonnull
+    private CloudOfThingsRestClient createRestClient() {
+        final CloudOfThingsRestClient client = mock(CloudOfThingsRestClient.class);
+        doAnswer(invocation -> readTemplate("pages/no-filter/empty-page.json"))
+            .when(client)
+            .getResponse(anyString());
+        return client;
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -1,16 +1,22 @@
 package com.telekom.m2m.cot.restsdk.util;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Scanner;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -42,7 +48,7 @@ public class IterableObjectPaginationTest {
         ) {
             @Nonnull
             @Override
-            protected ExtensibleObject convertJsonToObject(@Nonnull JsonElement element) {
+            protected ExtensibleObject convertJsonToObject(@Nonnull final JsonElement element) {
                 return gson.fromJson(element, ExtensibleObject.class);
             }
         };
@@ -74,6 +80,7 @@ public class IterableObjectPaginationTest {
 
         assertEquals(5, objects.size());
         assertPageNotRequested(3);
+        assertPageNotRequested(4);
     }
 
     @Test
@@ -86,6 +93,7 @@ public class IterableObjectPaginationTest {
         assertPageNotRequested(1);
         assertPageNotRequested(2);
         assertPageNotRequested(3);
+        assertPageNotRequested(4);
     }
 
     @Test
@@ -98,7 +106,34 @@ public class IterableObjectPaginationTest {
     }
 
     private void simulateNumberOfObjectsOnPages(final int numberOfObjects) {
-
+        if (numberOfObjects == 0) {
+            simulatePageResponse(1, readTemplate("pages/no-filter/empty-page.json"));
+            return;
+        }
+        final String pageTemplate = readTemplate("pages/no-filter/page.json.template");
+        final String itemTemplate = readTemplate("pages/no-filter/item.json.template");
+        final int totalPages = ceilDiv(numberOfObjects, PAGE_SIZE_IN_TESTS);
+        for (int page = 1; page <= totalPages; page++) {
+            final int itemsOnPage = (page == totalPages) ? numberOfObjects % PAGE_SIZE_IN_TESTS : PAGE_SIZE_IN_TESTS;
+            final String itemsJson = IntStream.range(1, itemsOnPage)
+                .mapToObj(id -> itemTemplate.replace("%%id%%", String.valueOf(id)))
+                .collect(Collectors.joining(","));
+            final String body = pageTemplate
+                .replace("%%totalPages%%", String.valueOf(totalPages))
+                .replace("%%pageSize%%", String.valueOf(PAGE_SIZE_IN_TESTS))
+                .replace("%%currentPage%%", String.valueOf(page))
+                .replace("%%previousPage%%", String.valueOf(page - 1))
+                .replace("%%nextPage%%", String.valueOf(page + 1))
+                .replace("%%items%%", itemsJson);
+            final JsonObject document = GsonUtils.createGson(true).fromJson(body, JsonElement.class).getAsJsonObject();
+            if (page == 1) {
+                document.remove("prev");
+            }
+            if (page == totalPages) {
+                document.remove("next");
+            }
+            simulatePageResponse(page, document.toString());
+        }
     }
 
     /**
@@ -106,10 +141,50 @@ public class IterableObjectPaginationTest {
      *
      * @param pageNumber The 1-indexed page number.
      */
-    private void assertPageNotRequested(int pageNumber) {
+    private void assertPageNotRequested(final int pageNumber) {
         assertTrue(
             pageNumber > 0,
             "Invalid page number value '" + pageNumber + "', page numbers *must* start at one."
         );
+        verify(cloudOfThingsRestClient, never()).getResponse(eq(pageUrl(pageNumber)));
+    }
+
+    /**
+     * Simulates a HTTP response body for the given page.
+     *
+     * @param pageNumber The number of the simulated page.
+     * @param body The returned content.
+     */
+    private void simulatePageResponse(final int pageNumber, @Nonnull final String body) {
+        doReturn(body)
+            .when(cloudOfThingsRestClient)
+            .getResponse(eq(pageUrl(pageNumber)));
+    }
+
+    /**
+     * @param pageNumber The 1-indexed page number.
+     * @return The API URL to the page.
+     */
+    @Nonnull
+    private String pageUrl(final int pageNumber) {
+        return "test/url?currentPage=" + pageNumber + "&pageSize=" + PAGE_SIZE_IN_TESTS;
+    }
+
+    /**
+     * Reads the content of a test data file.
+     *
+     * @param fileResourcePath Path to the resource, relative the test package.
+     * @return The file content.
+     */
+    @Nonnull
+    private String readTemplate(final String fileResourcePath) {
+        final InputStream input = getClass().getResourceAsStream(fileResourcePath);
+        try (final Scanner scanner = new Scanner(input, StandardCharsets.UTF_8.name())) {
+            return scanner.useDelimiter("\\A").next();
+        }
+    }
+
+    private int ceilDiv(final int dividend, final int divisor){
+        return -Math.floorDiv(-dividend,divisor);
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -42,7 +42,7 @@ public class IterableObjectPaginationTest {
             "test/url",
             GsonUtils.createGson(),
             "application/json",
-            "test-objects",
+            "operations",
             null,
             PAGE_SIZE_IN_TESTS
         ) {
@@ -60,7 +60,7 @@ public class IterableObjectPaginationTest {
 
         final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
 
-        assertEquals(10, objects.size());
+        assertEquals( objects.size(), 10);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class IterableObjectPaginationTest {
 
         final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
 
-        assertEquals(2, objects.size());
+        assertEquals(objects.size(), 2);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class IterableObjectPaginationTest {
 
         final List<ExtensibleObject> objects = pagination.stream().limit(5).collect(Collectors.toList());
 
-        assertEquals(5, objects.size());
+        assertEquals(objects.size(), 5);
         assertPageNotRequested(3);
         assertPageNotRequested(4);
     }
@@ -89,7 +89,7 @@ public class IterableObjectPaginationTest {
 
         final List<ExtensibleObject> objects = pagination.stream().limit(0).collect(Collectors.toList());
 
-        assertEquals(0, objects.size());
+        assertEquals(objects.size(), 0);
         assertPageNotRequested(1);
         assertPageNotRequested(2);
         assertPageNotRequested(3);
@@ -102,7 +102,7 @@ public class IterableObjectPaginationTest {
 
         final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
 
-        assertEquals(0, objects.size());
+        assertEquals(objects.size(), 0);
     }
 
     private void simulateNumberOfObjectsOnPages(final int numberOfObjects) {

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -79,8 +79,8 @@ public class IterableObjectPaginationTest {
         final List<ExtensibleObject> objects = pagination.stream().limit(5).collect(Collectors.toList());
 
         assertEquals(objects.size(), 5);
-        assertPageNotRequested(3);
         assertPageNotRequested(4);
+        assertPageNotRequested(3);
     }
 
     @Test
@@ -90,10 +90,10 @@ public class IterableObjectPaginationTest {
         final List<ExtensibleObject> objects = pagination.stream().limit(0).collect(Collectors.toList());
 
         assertEquals(objects.size(), 0);
-        assertPageNotRequested(1);
-        assertPageNotRequested(2);
-        assertPageNotRequested(3);
         assertPageNotRequested(4);
+        assertPageNotRequested(3);
+        assertPageNotRequested(2);
+        assertPageNotRequested(1);
     }
 
     @Test

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -88,6 +88,15 @@ public class IterableObjectPaginationTest {
         assertPageNotRequested(3);
     }
 
+    @Test
+    public void returnsNoObjectsIfPageIsEmpty() {
+        simulateNumberOfObjectsOnPages(0);
+
+        final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
+
+        assertEquals(0, objects.size());
+    }
+
     private void simulateNumberOfObjectsOnPages(final int numberOfObjects) {
 
     }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -1,0 +1,106 @@
+package com.telekom.m2m.cot.restsdk.util;
+
+import com.google.gson.JsonElement;
+import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class IterableObjectPaginationTest {
+
+    private static final int PAGE_SIZE_IN_TESTS = 3;
+
+    /**
+     * System under test.
+     */
+    private IterableObjectPagination<ExtensibleObject> pagination;
+
+    /**
+     * A mocked REST client.
+     */
+    private CloudOfThingsRestClient cloudOfThingsRestClient;
+
+    @BeforeTest
+    public void setup() {
+        cloudOfThingsRestClient = mock(CloudOfThingsRestClient.class);
+        pagination = new IterableObjectPagination<ExtensibleObject>(
+            cloudOfThingsRestClient,
+            "test/url",
+            GsonUtils.createGson(),
+            "application/json",
+            "test-objects",
+            null,
+            PAGE_SIZE_IN_TESTS
+        ) {
+            @Nonnull
+            @Override
+            protected ExtensibleObject convertJsonToObject(@Nonnull JsonElement element) {
+                return gson.fromJson(element, ExtensibleObject.class);
+            }
+        };
+    }
+
+    @Test
+    public void streamReadsObjectsUntilLastPageIsReached() {
+        simulateNumberOfObjectsOnPages(10);
+
+        final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
+
+        assertEquals(10, objects.size());
+    }
+
+    @Test
+    public void streamReadsObjectsIfThereIsOnlyOnePage() {
+        simulateNumberOfObjectsOnPages(2);
+
+        final List<ExtensibleObject> objects = pagination.stream().collect(Collectors.toList());
+
+        assertEquals(2, objects.size());
+    }
+
+    @Test
+    public void loadsOnlyNecessaryPagesIfNotAllObjectsInStreamAreConsumed() {
+        simulateNumberOfObjectsOnPages(10);
+
+        final List<ExtensibleObject> objects = pagination.stream().limit(5).collect(Collectors.toList());
+
+        assertEquals(5, objects.size());
+        assertPageNotRequested(3);
+    }
+
+    @Test
+    public void doesNotLoadAnyPageIfStreamDoesNotReadAnyObject() {
+        simulateNumberOfObjectsOnPages(10);
+
+        final List<ExtensibleObject> objects = pagination.stream().limit(0).collect(Collectors.toList());
+
+        assertEquals(0, objects.size());
+        assertPageNotRequested(1);
+        assertPageNotRequested(2);
+        assertPageNotRequested(3);
+    }
+
+    private void simulateNumberOfObjectsOnPages(final int numberOfObjects) {
+
+    }
+
+    /**
+     * Asserts that the given page was *not* requested via HTTP.
+     *
+     * @param pageNumber The 1-indexed page number.
+     */
+    private void assertPageNotRequested(int pageNumber) {
+        assertTrue(
+            pageNumber > 0,
+            "Invalid page number value '" + pageNumber + "', page numbers *must* start at one."
+        );
+    }
+}

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/IterableObjectPaginationTest.java
@@ -1,5 +1,6 @@
 package com.telekom.m2m.cot.restsdk.util;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
@@ -39,7 +40,9 @@ public class IterableObjectPaginationTest {
     @BeforeMethod
     public void setup() {
         cloudOfThingsRestClient = createRestClient();
-        pagination = new IterableObjectPagination<ExtensibleObject>(
+        final Gson gson = GsonUtils.createGson();
+        pagination = new IterableObjectPagination<>(
+            (json) -> gson.fromJson(json, ExtensibleObject.class),
             cloudOfThingsRestClient,
             "test/url",
             GsonUtils.createGson(),
@@ -47,13 +50,7 @@ public class IterableObjectPaginationTest {
             "operations",
             null,
             PAGE_SIZE_IN_TESTS
-        ) {
-            @Nonnull
-            @Override
-            protected ExtensibleObject convertJsonToObject(@Nonnull final JsonElement element) {
-                return gson.fromJson(element, ExtensibleObject.class);
-            }
-        };
+        );
     }
 
     @Test

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPaginationTest.java
@@ -114,7 +114,7 @@ public class JsonArrayPaginationTest {
         Mockito.when(cotRestClientMock.getResponse(url)).thenThrow(new CotSdkException("exception was thrown"));
 
         // when
-        JsonArray jsonArray = jsonArrayPagination.getJsonArray();
+        jsonArrayPagination.getJsonArray();
 
         // then an exception should be thrown
     }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPaginationTest.java
@@ -143,16 +143,15 @@ public class JsonArrayPaginationTest {
         // given
         final CloudOfThingsRestClient cotRestClientMock = Mockito.mock(CloudOfThingsRestClient.class);
         final JsonArrayPagination jsonArrayPagination = createJsonArrayPagination(cotRestClientMock);
+        jsonArrayPagination.setPageSize(2);
 
-        final String jsonResultPageEmpty = "{\"auditRecords\":[]}";
-        final String jsonResultPage1 = "{\"auditRecords\":[{\"id\":\"1\"}]}";
-        final String jsonResultPage2 = "{\"auditRecords\":[{\"id\":\"2\"}],\"prev\":\"page1\"}";
-        final String urlPage0 = relativeApiUrl + "?currentPage=0&pageSize=5";
-        final String urlPage1 = relativeApiUrl + "?currentPage=1&pageSize=5";
-        final String urlPage2 = relativeApiUrl + "?currentPage=2&pageSize=5";
-        final String urlPage3 = relativeApiUrl + "?currentPage=3&pageSize=5";
+        final String jsonResultPageEmpty = "{\"auditRecords\":[], \"statistics\": {\"currentPage\": 4, \"pageSize\": 2}}";
+        final String jsonResultPage1 = "{\"auditRecords\":[{\"id\":\"1\"}, {\"id\":\"2\"}], \"next\": \"page2\", \"statistics\": {\"currentPage\": 1, \"pageSize\": 2}}";
+        final String jsonResultPage2 = "{\"auditRecords\":[{\"id\":\"3\"}],\"prev\":\"page1\", \"next\": \"page3\", \"statistics\": {\"currentPage\": 2, \"pageSize\": 2}}";
+        final String urlPage1 = relativeApiUrl + "?currentPage=1&pageSize=2";
+        final String urlPage2 = relativeApiUrl + "?currentPage=2&pageSize=2";
+        final String urlPage3 = relativeApiUrl + "?currentPage=3&pageSize=2";
 
-        Mockito.when(cotRestClientMock.getResponse(urlPage0)).thenReturn(jsonResultPage1);
         Mockito.when(cotRestClientMock.getResponse(urlPage1)).thenReturn(jsonResultPage1);
         Mockito.when(cotRestClientMock.getResponse(urlPage2)).thenReturn(jsonResultPage2);
         Mockito.when(cotRestClientMock.getResponse(urlPage3)).thenReturn(jsonResultPageEmpty);
@@ -162,7 +161,7 @@ public class JsonArrayPaginationTest {
 
         // then you'll get the first page
         Assert.assertNotNull(jsonArray);
-        Assert.assertEquals(jsonArray.size(), 1);
+        Assert.assertEquals(jsonArray.size(), 2);
         Assert.assertNotNull(jsonArray.get(0).getAsJsonObject());
         Assert.assertTrue(jsonArray.get(0).getAsJsonObject().get("id").getAsString().equals("1"));
         Assert.assertFalse(jsonArrayPagination.hasPrevious());
@@ -176,7 +175,7 @@ public class JsonArrayPaginationTest {
         Assert.assertNotNull(jsonArray);
         Assert.assertEquals(jsonArray.size(), 1);
         Assert.assertNotNull(jsonArray.get(0).getAsJsonObject());
-        Assert.assertTrue(jsonArray.get(0).getAsJsonObject().get("id").getAsString().equals("2"));
+        Assert.assertTrue(jsonArray.get(0).getAsJsonObject().get("id").getAsString().equals("3"));
         Assert.assertTrue(jsonArrayPagination.hasPrevious());
         Assert.assertFalse(jsonArrayPagination.hasNext());
 
@@ -186,7 +185,7 @@ public class JsonArrayPaginationTest {
 
         // then you'll get the first page again
         Assert.assertNotNull(jsonArray);
-        Assert.assertEquals(jsonArray.size(), 1);
+        Assert.assertEquals(jsonArray.size(), 2);
         Assert.assertNotNull(jsonArray.get(0).getAsJsonObject());
         Assert.assertTrue(jsonArray.get(0).getAsJsonObject().get("id").getAsString().equals("1"));
         Assert.assertFalse(jsonArrayPagination.hasPrevious());
@@ -198,7 +197,7 @@ public class JsonArrayPaginationTest {
 
         // then you'll still stay at the first page
         Assert.assertNotNull(jsonArray);
-        Assert.assertEquals(jsonArray.size(), 1);
+        Assert.assertEquals(jsonArray.size(), 2);
         Assert.assertNotNull(jsonArray.get(0).getAsJsonObject());
         Assert.assertTrue(jsonArray.get(0).getAsJsonObject().get("id").getAsString().equals("1"));
         Assert.assertFalse(jsonArrayPagination.hasPrevious());

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPaginationTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/JsonArrayPaginationTest.java
@@ -103,6 +103,7 @@ public class JsonArrayPaginationTest {
         Assert.assertNotNull(jsonArray);
         Assert.assertEquals(jsonArray.size(), 0);
         Assert.assertFalse(jsonArrayPagination.hasPrevious());
+        Assert.assertFalse(jsonArrayPagination.hasNext());
     }
 
     @Test(expectedExceptions = CotSdkException.class)

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/README.md
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/README.md
@@ -1,0 +1,10 @@
+# Pages #
+
+This directory contains some paged example responses from the Cumulocity REST API.
+
+Additionally, it contains a template file `page.json.template` that is used to create mock responses in tests.
+
+Observations: 
+
+- When filters are applied, then no total number of pages is available.
+- When filters are applied, then the response contains *always* a `next` attribute, even if there is no next page.

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/filtered/empty-page.json
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/filtered/empty-page.json
@@ -1,0 +1,9 @@
+{
+  "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=4&currentPage=2&status=EXECUTING",
+  "operations": [],
+  "statistics": {
+    "currentPage": 1,
+    "pageSize": 4
+  },
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=4&currentPage=1&status=EXECUTING"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/filtered/first-page.json
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/filtered/first-page.json
@@ -1,0 +1,58 @@
+{
+  "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=4&currentPage=2&status=PENDING",
+  "operations": [
+    {
+      "creationTime": "2018-05-02T15:15:37.664+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18039",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18039",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    },
+    {
+      "creationTime": "2018-05-02T15:15:44.678+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18041",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18041",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    },
+    {
+      "creationTime": "2018-05-02T15:15:45.943+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18043",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18043",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    },
+    {
+      "creationTime": "2018-05-02T15:15:47.188+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18045",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18045",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    }
+  ],
+  "statistics": {
+    "currentPage": 1,
+    "pageSize": 4
+  },
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=4&currentPage=1&status=PENDING"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/empty-page.json
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/empty-page.json
@@ -1,0 +1,9 @@
+{
+  "operations": [],
+  "statistics": {
+    "currentPage": 1,
+    "pageSize": 1,
+    "totalPages": 0
+  },
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=1&currentPage=1"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/first-page.json
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/first-page.json
@@ -1,0 +1,35 @@
+{
+  "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=2&currentPage=2",
+  "operations": [
+    {
+      "creationTime": "2018-05-02T15:15:37.664+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18039",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18039",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    },
+    {
+      "creationTime": "2018-05-02T15:15:44.678+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18041",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18041",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    }
+  ],
+  "statistics": {
+    "currentPage": 1,
+    "pageSize": 2,
+    "totalPages": 7
+  },
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=2&currentPage=1"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/item.json.template
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/item.json.template
@@ -1,0 +1,12 @@
+{
+  "creationTime": "2018-05-02T15:15:50.064+02:00",
+  "deviceId": "%%id%%",
+  "deviceName": "%%id%%",
+  "id": "%%id%%",
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/%%id%%",
+  "status": "PENDING",
+  "c8y_Command": {
+    "text": "ls -la"
+  },
+  "description": "Execute shell command"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/last-page.json
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/last-page.json
@@ -1,0 +1,23 @@
+{
+  "operations": [
+    {
+      "creationTime": "2018-05-02T15:18:18.417+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18063",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18063",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    }
+  ],
+  "statistics": {
+    "currentPage": 7,
+    "pageSize": 2,
+    "totalPages": 7
+  },
+  "prev": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=2&currentPage=6",
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=2&currentPage=7"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/middle-page.json
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/middle-page.json
@@ -1,0 +1,36 @@
+{
+  "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=2&currentPage=4",
+  "operations": [
+    {
+      "creationTime": "2018-05-02T15:15:48.845+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18047",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18047",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    },
+    {
+      "creationTime": "2018-05-02T15:15:50.064+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18049",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18049",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    }
+  ],
+  "statistics": {
+    "currentPage": 3,
+    "pageSize": 2,
+    "totalPages": 7
+  },
+  "prev": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=2&currentPage=2",
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=2&currentPage=3"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/page.json.template
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/page.json.template
@@ -1,0 +1,36 @@
+{
+  "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%currentPage%%",
+  "operations": [
+    {
+      "creationTime": "2018-05-02T15:15:48.845+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18047",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18047",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    },
+    {
+      "creationTime": "2018-05-02T15:15:50.064+02:00",
+      "deviceId": "17415",
+      "deviceName": "123456787654333",
+      "id": "18049",
+      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18049",
+      "status": "PENDING",
+      "c8y_Command": {
+        "text": "ls -la"
+      },
+      "description": "Execute shell command"
+    }
+  ],
+  "statistics": {
+    "currentPage": %%currentPage%%,
+    "pageSize": %%pageSize%%,
+    "totalPages": %%totalPages%%
+  },
+  "prev": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%previousPage%%",
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%nextPage%%"
+}

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/page.json.template
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/page.json.template
@@ -1,6 +1,8 @@
 {
   "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%nextPage%%",
-  "operations": [],
+  "operations": [
+    %%items%%
+  ],
   "statistics": {
     "currentPage": %%currentPage%%,
     "pageSize": %%pageSize%%,

--- a/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/page.json.template
+++ b/src/test/resources/com/telekom/m2m/cot/restsdk/util/pages/no-filter/page.json.template
@@ -1,36 +1,11 @@
 {
-  "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%currentPage%%",
-  "operations": [
-    {
-      "creationTime": "2018-05-02T15:15:48.845+02:00",
-      "deviceId": "17415",
-      "deviceName": "123456787654333",
-      "id": "18047",
-      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18047",
-      "status": "PENDING",
-      "c8y_Command": {
-        "text": "ls -la"
-      },
-      "description": "Execute shell command"
-    },
-    {
-      "creationTime": "2018-05-02T15:15:50.064+02:00",
-      "deviceId": "17415",
-      "deviceName": "123456787654333",
-      "id": "18049",
-      "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations/18049",
-      "status": "PENDING",
-      "c8y_Command": {
-        "text": "ls -la"
-      },
-      "description": "Execute shell command"
-    }
-  ],
+  "next": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%nextPage%%",
+  "operations": [],
   "statistics": {
     "currentPage": %%currentPage%%,
     "pageSize": %%pageSize%%,
     "totalPages": %%totalPages%%
   },
   "prev": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%previousPage%%",
-  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%nextPage%%"
+  "self": "https://mytenant.int2-ram.m2m.telekom.com/devicecontrol/operations?pageSize=%%pageSize%%&currentPage=%%currentPage%%"
 }


### PR DESCRIPTION
Introduced a `stream()` method that allows to iterate over *all* pages of a collection. 
The pagination is performed automatically in the background, only required pages are fetched via API call.

Additionally, the performance of paging has been improved in general (fixes #72).

The new `stream()` method is provided by the class `IterableObjectPagination`. All collections have been updated to inherit from that class.
The previous base class `JsonArrayPagination` still exists and its behavior was not changed, so this pull request should be completely backward compatible.