### PR TITLE
Remove unused tests for inventory API

### DIFF
--- a/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryManagedObjectCollectionIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryManagedObjectCollectionIT.java
@@ -42,7 +42,7 @@ public class InventoryManagedObjectCollectionIT {
     }
 
     @Test
-    public void testMultipleManagedObjects() throws Exception {
+    public void testMultipleManagedObjects() {
         // Expects a tenant with already multiple measurements
 
         InventoryApi inventoryApi = cotPlat.getInventoryApi();
@@ -63,7 +63,7 @@ public class InventoryManagedObjectCollectionIT {
     }
 
     @Test
-    public void testMultipleManagedObjectsWithPaging() throws Exception {
+    public void testMultipleManagedObjectsWithPaging() {
         // Expects a tenant with already multiple measurements
 
         InventoryApi inventoryApi = cotPlat.getInventoryApi();
@@ -112,7 +112,7 @@ public class InventoryManagedObjectCollectionIT {
     }
 
     @Test
-    public void testMultipleManagedObjectsByText() throws Exception {
+    public void testMultipleManagedObjectsByText() {
         InventoryApi inventoryApi = cotPlat.getInventoryApi();
         ManagedObject testManagedObject = TestHelper.createRandomManagedObjectInPlatform(cotPlat, "my_specialxxyyzz_name");
 
@@ -131,7 +131,7 @@ public class InventoryManagedObjectCollectionIT {
     }
 
     @Test
-    public void testMultipleManagedObjectsByListOfIDs() throws Exception {
+    public void testMultipleManagedObjectsByListOfIDs() {
         InventoryApi inventoryApi = cotPlat.getInventoryApi();
         ManagedObject testManagedObject = TestHelper.createRandomManagedObjectInPlatform(cotPlat, "my_specialxxyyzz_name");
 

--- a/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryManagedObjectCollectionIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryManagedObjectCollectionIT.java
@@ -111,28 +111,6 @@ public class InventoryManagedObjectCollectionIT {
         softAssert.assertAll();
     }
 
-//    @Test
-//    public void testDeleteMultipleOperationsBySource() throws Exception {
-//        DeviceControlApi deviceControlApi = cotPlat.getDeviceControlApi();
-//
-//        for (int i = 0; i < 6; i++) {
-//            Operation testOperation = new Operation();
-//            testOperation.setDeviceId(testManagedObject.getId());
-//            testOperation.set("com_telekom_m2m_cotcommand", jsonObject);
-//
-//            deviceControlApi.create(testOperation);
-//        }
-//
-//        OperationCollection operations = deviceControlApi.getOperations(Filter.build().byDeviceId(testManagedObject.getId()), 5);
-//        Operation[] os = operations.getOperations();
-//        Assert.assertEquals(os.length, 5);
-//
-//        deviceControlApi.deleteOperations(Filter.build().byDeviceId(testManagedObject.getId()));
-//        operations = deviceControlApi.getOperations(Filter.build().byDeviceId(testManagedObject.getId()), 5);
-//        os = operations.getOperations();
-//        Assert.assertEquals(os.length, 0);
-//    }
-
     @Test
     public void testMultipleManagedObjectsByText() throws Exception {
         InventoryApi inventoryApi = cotPlat.getInventoryApi();
@@ -166,44 +144,6 @@ public class InventoryManagedObjectCollectionIT {
         inventoryApi.delete(testManagedObject.getId());
         softAssert.assertAll();
     }
-
-//    @Test
-//    public void testMultipleManagedObjectsByFragment() throws Exception {
-//        InventoryApi inventoryApi = cotPlat.getInventoryApi();
-//        ManagedObject testManagedObject  = TestHelper.createManagedObject("IT-Test-MO_DELETE");
-//        testManagedObject = inventoryApi.create(testManagedObject);
-//
-//        SampleTemperatureSensor sts = new SampleTemperatureSensor();
-//        sts.setTemperature(10);
-//
-//        Measurement measurement = new Measurement();
-//        measurement.setTime(new Date());
-//        measurement.setType("com_telekom_TestType");
-//        measurement.setSource(testManagedObject);
-//        measurement.set(sts);
-//
-//        MeasurementApi measurementApi = cotPlat.getMeasurementApi();
-//        Measurement createdMeasurements = measurementApi.createMeasurement(measurement);
-//
-//        testManagedObject = inventoryApi.get(testManagedObject.getId());
-//
-//        ManagedObjectCollection managedObjects = inventoryApi.getManagedObjects(Filter.build().byFragmentType("com_telekom_m2m_cot_restsdk_util_SampleTemperatureSensor"), 5);
-//        ManagedObject[] mos = managedObjects.getManagedObjects();
-//        Assert.assertTrue(mos.length > 0);
-//        boolean allOperationWithSameStatus = true;
-//        for (ManagedObject o : mos) {
-//            if (!o.getName().equals("IT-Test-MO_DELETE")) {
-//                allOperationWithSameStatus = false;
-//            }
-//        }
-//        softAssert.assertFalse(allOperationWithSameStatus, "Don't got the wanted MOs");
-//
-//        inventoryApi.delete(testManagedObject.getId());
-//
-//        softAssert.assertAll();
-//
-//    }
-
 
     @Test
     public void testRegisterAsChildDevice() {

--- a/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryManagedObjectCollectionIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryManagedObjectCollectionIT.java
@@ -56,7 +56,7 @@ public class InventoryManagedObjectCollectionIT {
 
         ManagedObject managedObject = managedObjects[0];
 
-        Assert.assertTrue(managedObject.getId() != null);
+        Assert.assertNotNull(managedObject.getId());
         Assert.assertTrue(managedObject.getId().length() > 0);
 
 


### PR DESCRIPTION
Some tests have been commented out in 2016 and were unused since then.

This pull request removes these tests as they do not provide value anymore in 2018.
Additionally, some minor code cleanup has been applied to the affected test case.