### PR TITLE
Filter improvements

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -67,7 +67,7 @@ Run the integration tests:
     export COT_TEST_CONNECTION_PASSWORD="your-password"
     export COT_TEST_CONNECTION_TENANT="your-tenant"
 
-    mvn integration-test
+    mvn -Dgpg.skip=true integration-test
     
 The integration tests require a Cloud of Things account. You must provide the credentials that are used for testing via environment variables before starting the integration tests.
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.*;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -96,7 +97,7 @@ public class AlarmApi {
      * @return the found Alarms in a pageable collection.
      * @since 0.3.0
      */
-    public AlarmCollection getAlarms(Filter.FilterBuilder filters, int resultSize) {
+    public AlarmCollection getAlarms(@Nullable Filter.FilterBuilder filters, int resultSize) {
         if(filters != null) {
             filters.validateSupportedFilters(acceptedFilters);
         }
@@ -113,7 +114,7 @@ public class AlarmApi {
      *
      * @param filters filters of Alarm attributes.
      */
-    public void deleteAlarms(Filter.FilterBuilder filters) {
+    public void deleteAlarms(@Nullable Filter.FilterBuilder filters) {
         if(filters != null) {
             filters.validateSupportedFilters(acceptedFilters);
         }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
@@ -7,6 +7,7 @@ import com.telekom.m2m.cot.restsdk.util.*;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Use AlarmApi to work with Alarms.
@@ -114,10 +115,13 @@ public class AlarmApi {
      *
      * @param filters filters of Alarm attributes.
      */
-    public void deleteAlarms(@Nullable Filter.FilterBuilder filters) {
+    public void deleteAlarms(@Nullable final Filter.FilterBuilder filters) {
         if(filters != null) {
             filters.validateSupportedFilters(acceptedFilters);
         }
-        cloudOfThingsRestClient.delete("", RELATIVE_API_URL+ "?" + filters.buildFilter() + "&x=");
+        final String filterParams = Optional.ofNullable(filters)
+            .map(filterBuilder -> filterBuilder.buildFilter() + "&")
+            .orElse("");
+        cloudOfThingsRestClient.delete("", RELATIVE_API_URL + "?" + filterParams + "x=");
     }
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
@@ -122,6 +122,7 @@ public class AlarmApi {
         final String filterParams = Optional.ofNullable(filters)
             .map(filterBuilder -> filterBuilder.buildFilter() + "&")
             .orElse("");
+        // The x query parameter is a workaround. Without, it seems as if there are cases where deletion does not work.
         cloudOfThingsRestClient.delete("", RELATIVE_API_URL + "?" + filterParams + "x=");
     }
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApi.java
@@ -41,8 +41,7 @@ public class AlarmApi {
      */
     public Alarm getAlarm(String alarmId) {
         String response = cloudOfThingsRestClient.getResponse(alarmId, RELATIVE_API_URL, CONTENT_TYPE);
-        Alarm alarm = new Alarm(gson.fromJson(response, ExtensibleObject.class));
-        return alarm;
+        return new Alarm(gson.fromJson(response, ExtensibleObject.class));
     }
 
     /**

--- a/src/main/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApi.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApi.java
@@ -7,9 +7,11 @@ import com.google.gson.JsonParser;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.*;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The API object to operate with Measurements in the platform.
@@ -138,11 +140,15 @@ public class MeasurementApi {
      *
      * @param filters filters of measurement attributes.
      */
-    public void deleteMeasurements(Filter.FilterBuilder filters) {
+    public void deleteMeasurements(@Nullable final Filter.FilterBuilder filters) {
         if(filters != null) {
             filters.validateSupportedFilters(acceptedFilters);
         }
-        cloudOfThingsRestClient.delete("", MEASUREMENTS_API + "?" + filters.buildFilter() + "&x=");
+        final String filterParams = Optional.ofNullable(filters)
+            .map(filterBuilder -> filterBuilder.buildFilter() + "&")
+            .orElse("");
+        // The x query parameter is a workaround. Without, it seems as if there are cases where deletion does not work.
+        cloudOfThingsRestClient.delete("", MEASUREMENTS_API + "?" + filterParams + "x=");
     }
 
     private JsonObject createJsonObject(final List<Measurement> measurements) {

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -15,7 +15,7 @@ import java.util.*;
 public class Filter {
 
     @Nonnull
-    private final HashMap<String, String> arguments = new HashMap<>();
+    private final HashMap<FilterBy, String> arguments = new HashMap<>();
 
     private Filter() {
     }
@@ -57,10 +57,8 @@ public class Filter {
         @Nonnull
         public String buildFilter() {
             String qs = "";
-            Set<Map.Entry<String, String>> set = instance.arguments.entrySet();
-
-            for (Map.Entry<String, String> entry : set) {
-                qs += entry.getKey() + "=" + entry.getValue() + "&";
+            for (final Map.Entry<FilterBy, String> entry : instance.arguments.entrySet()) {
+                qs += entry.getKey().toString() + "=" + entry.getValue() + "&";
             }
             return qs.substring(0, qs.length() - 1);
         }
@@ -74,7 +72,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder bySource(String id) {
-            instance.arguments.put("source", id);
+            instance.arguments.put(FilterBy.BYSOURCE, id);
             return this;
         }
 
@@ -87,8 +85,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byType(String type) {
-            //instance.type = type;
-            instance.arguments.put("type", type);
+            instance.arguments.put(FilterBy.BYTYPE, type);
             return this;
         }
 
@@ -102,10 +99,8 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byDate(Date from, Date to) {
-            //instance.dateFrom = from;
-            //instance.dateTo = to;
-            instance.arguments.put("dateFrom", CotUtils.convertDateToTimestring(from));
-            instance.arguments.put("dateTo", CotUtils.convertDateToTimestring(to));
+            instance.arguments.put(FilterBy.BYDATEFROM, CotUtils.convertDateToTimestring(from));
+            instance.arguments.put(FilterBy.BYDATETO, CotUtils.convertDateToTimestring(to));
             return this;
         }
 
@@ -118,7 +113,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byFragmentType(String fragmentType) {
-            instance.arguments.put("fragmentType", fragmentType);
+            instance.arguments.put(FilterBy.BYFRAGMENTTYPE, fragmentType);
             return this;
         }
 
@@ -131,7 +126,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byDeviceId(String deviceId) {
-            instance.arguments.put("deviceId", deviceId);
+            instance.arguments.put(FilterBy.BYDEVICEID, deviceId);
             return this;
         }
 
@@ -144,7 +139,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byStatus(OperationStatus operationStatus) {
-            instance.arguments.put("status", operationStatus.toString());
+            instance.arguments.put(FilterBy.BYSTATUS, operationStatus.toString());
             return this;
         }
 
@@ -157,7 +152,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byText(String text) {
-            instance.arguments.put("text", text);
+            instance.arguments.put(FilterBy.BYTEXT, text);
             return this;
         }
 
@@ -170,7 +165,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byListOfIds(String listOfIds) {
-            instance.arguments.put("ids", listOfIds);
+            instance.arguments.put(FilterBy.BYLISTOFIDs, listOfIds);
             return this;
         }
 
@@ -184,7 +179,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byStatus(String status) {
-            instance.arguments.put("status", status);
+            instance.arguments.put(FilterBy.BYSTATUS, status);
             return this;
         }
 
@@ -198,7 +193,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byAgentId(String agentId) {
-            instance.arguments.put("agentId", agentId);
+            instance.arguments.put(FilterBy.BYAGENTID, agentId);
             return this;
         }
 
@@ -212,7 +207,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byUser(String user) {
-            instance.arguments.put("user", user);
+            instance.arguments.put(FilterBy.BYUSER, user);
             return this;
         }
         
@@ -226,7 +221,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byApplication(String application) {
-            instance.arguments.put("application", application);
+            instance.arguments.put(FilterBy.BYAPPLICATION, application);
             return this;
         }
 
@@ -238,8 +233,8 @@ public class Filter {
          * @return an appropriate build Object
          */
         @Nonnull
-        public FilterBuilder setFilter(FilterBy filterBy, String value) {
-           instance.arguments.put(filterBy.getFilterKey(), value);
+        public FilterBuilder setFilter(@Nonnull final FilterBy filterBy, @Nonnull final String value) {
+           instance.arguments.put(filterBy, value);
            return this;
         }
 
@@ -250,9 +245,9 @@ public class Filter {
          * @return an appropriate build Object
          */
         @Nonnull
-        public FilterBuilder setFilters(@Nonnull HashMap<FilterBy, String> hashmap){
-            for (Map.Entry<FilterBy, String> e : hashmap.entrySet()){
-                instance.arguments.put(e.getKey().getFilterKey(), e.getValue());
+        public FilterBuilder setFilters(@Nonnull final HashMap<FilterBy, String> hashmap){
+            for (final Map.Entry<FilterBy, String> e : hashmap.entrySet()){
+                instance.arguments.put(e.getKey(), e.getValue());
             }
             return this;
         }
@@ -266,14 +261,13 @@ public class Filter {
         public void validateSupportedFilters(@Nullable final List<FilterBy> acceptedFilters) {
             // Do nothing, when all filters are accepted.
             if (acceptedFilters != null) {
-                for (final Map.Entry<String, String> definedFilter : instance.arguments.entrySet()) {
-                    if (!acceptedFilters.contains(FilterBy.getFilterBy(definedFilter.getKey()))) {
+                for (final Map.Entry<FilterBy, String> definedFilter : instance.arguments.entrySet()) {
+                    if (!acceptedFilters.contains(definedFilter.getKey())) {
                         throw new CotSdkException(String.format("This filter is not available in used api [%s]", definedFilter.getKey()));
                     }
                 }
             }
         }
-
     }
 
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -238,13 +238,13 @@ public class Filter {
         }
 
         /**
-         * adds a build for a hashmap of filters
+         * adds a build for a map of filters
          *
          * @param filtersToAdd contains enum values and values for filter builds
          * @return an appropriate build Object
          */
         @Nonnull
-        public FilterBuilder setFilters(@Nonnull final HashMap<FilterBy, String> filtersToAdd){
+        public FilterBuilder setFilters(@Nonnull final Map<FilterBy, String> filtersToAdd){
             instance.arguments.putAll(filtersToAdd);
             return this;
         }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -5,6 +5,7 @@ import com.telekom.m2m.cot.restsdk.devicecontrol.OperationStatus;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Filter to build as criteria for collection queries.
@@ -56,11 +57,9 @@ public class Filter {
          */
         @Nonnull
         public String buildFilter() {
-            String qs = "";
-            for (final Map.Entry<FilterBy, String> entry : instance.arguments.entrySet()) {
-                qs += entry.getKey().toString() + "=" + entry.getValue() + "&";
-            }
-            return qs.substring(0, qs.length() - 1);
+            return instance.arguments.entrySet().stream()
+                .map(entry -> entry.getKey().toString() + "=" + entry.getValue())
+                .collect(Collectors.joining("&"));
         }
 
         /**

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -260,14 +260,14 @@ public class Filter {
         /**
          * validate all set filters allowed by the api
          *
-         * @param notAllowedFilters list of filters, which are not allowed.
+         * @param acceptedFilters list of filters, which are allowed. Pass null if all filters are allowed.
          * @throws CotSdkException If a filter that is not allowed is detected.
          */
-        public void validateSupportedFilters(@Nullable final List notAllowedFilters) {
-            // Do nothing, when no filters are blacklisted.
-            if (notAllowedFilters != null) {
+        public void validateSupportedFilters(@Nullable final List acceptedFilters) {
+            // Do nothing, when all filters are accepted.
+            if (acceptedFilters != null) {
                 for (final Map.Entry<String, String> definedFilter : instance.arguments.entrySet()) {
-                    if (!notAllowedFilters.contains(FilterBy.getFilterBy(definedFilter.getKey()))) {
+                    if (!acceptedFilters.contains(FilterBy.getFilterBy(definedFilter.getKey()))) {
                         throw new CotSdkException(String.format("This filter is not available in used api [%s]", definedFilter.getKey()));
                     }
                 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -13,7 +13,8 @@ import java.util.*;
  */
 public class Filter {
 
-    private HashMap<String, String> arguments = new HashMap<>();
+    @Nonnull
+    private final HashMap<String, String> arguments = new HashMap<>();
 
     private Filter() {
     }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class Filter {
 
     @Nonnull
-    private final HashMap<FilterBy, String> arguments = new HashMap<>();
+    private final HashMap<FilterBy, String> filters = new HashMap<>();
 
     private Filter() {
     }
@@ -57,7 +57,7 @@ public class Filter {
          */
         @Nonnull
         public String buildFilter() {
-            return instance.arguments.entrySet().stream()
+            return instance.filters.entrySet().stream()
                 .map(filter -> filter.getKey().getFilterKey() + "=" + filter.getValue())
                 .collect(Collectors.joining("&"));
         }
@@ -71,7 +71,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder bySource(String id) {
-            instance.arguments.put(FilterBy.BYSOURCE, id);
+            instance.filters.put(FilterBy.BYSOURCE, id);
             return this;
         }
 
@@ -84,7 +84,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byType(String type) {
-            instance.arguments.put(FilterBy.BYTYPE, type);
+            instance.filters.put(FilterBy.BYTYPE, type);
             return this;
         }
 
@@ -98,8 +98,8 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byDate(Date from, Date to) {
-            instance.arguments.put(FilterBy.BYDATEFROM, CotUtils.convertDateToTimestring(from));
-            instance.arguments.put(FilterBy.BYDATETO, CotUtils.convertDateToTimestring(to));
+            instance.filters.put(FilterBy.BYDATEFROM, CotUtils.convertDateToTimestring(from));
+            instance.filters.put(FilterBy.BYDATETO, CotUtils.convertDateToTimestring(to));
             return this;
         }
 
@@ -112,7 +112,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byFragmentType(String fragmentType) {
-            instance.arguments.put(FilterBy.BYFRAGMENTTYPE, fragmentType);
+            instance.filters.put(FilterBy.BYFRAGMENTTYPE, fragmentType);
             return this;
         }
 
@@ -125,7 +125,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byDeviceId(String deviceId) {
-            instance.arguments.put(FilterBy.BYDEVICEID, deviceId);
+            instance.filters.put(FilterBy.BYDEVICEID, deviceId);
             return this;
         }
 
@@ -138,7 +138,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byStatus(OperationStatus operationStatus) {
-            instance.arguments.put(FilterBy.BYSTATUS, operationStatus.toString());
+            instance.filters.put(FilterBy.BYSTATUS, operationStatus.toString());
             return this;
         }
 
@@ -151,7 +151,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byText(String text) {
-            instance.arguments.put(FilterBy.BYTEXT, text);
+            instance.filters.put(FilterBy.BYTEXT, text);
             return this;
         }
 
@@ -164,7 +164,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byListOfIds(String listOfIds) {
-            instance.arguments.put(FilterBy.BYLISTOFIDs, listOfIds);
+            instance.filters.put(FilterBy.BYLISTOFIDs, listOfIds);
             return this;
         }
 
@@ -178,7 +178,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byStatus(String status) {
-            instance.arguments.put(FilterBy.BYSTATUS, status);
+            instance.filters.put(FilterBy.BYSTATUS, status);
             return this;
         }
 
@@ -192,7 +192,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byAgentId(String agentId) {
-            instance.arguments.put(FilterBy.BYAGENTID, agentId);
+            instance.filters.put(FilterBy.BYAGENTID, agentId);
             return this;
         }
 
@@ -206,7 +206,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byUser(String user) {
-            instance.arguments.put(FilterBy.BYUSER, user);
+            instance.filters.put(FilterBy.BYUSER, user);
             return this;
         }
         
@@ -220,7 +220,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byApplication(String application) {
-            instance.arguments.put(FilterBy.BYAPPLICATION, application);
+            instance.filters.put(FilterBy.BYAPPLICATION, application);
             return this;
         }
 
@@ -233,7 +233,7 @@ public class Filter {
          */
         @Nonnull
         public FilterBuilder setFilter(@Nonnull final FilterBy filterBy, @Nonnull final String value) {
-           instance.arguments.put(filterBy, value);
+           instance.filters.put(filterBy, value);
            return this;
         }
 
@@ -245,7 +245,7 @@ public class Filter {
          */
         @Nonnull
         public FilterBuilder setFilters(@Nonnull final Map<FilterBy, String> filtersToAdd){
-            instance.arguments.putAll(filtersToAdd);
+            instance.filters.putAll(filtersToAdd);
             return this;
         }
 
@@ -258,7 +258,7 @@ public class Filter {
         public void validateSupportedFilters(@Nullable final List<FilterBy> acceptedFilters) {
             // Do nothing, when all filters are accepted.
             if (acceptedFilters != null) {
-                for (final Map.Entry<FilterBy, String> definedFilter : instance.arguments.entrySet()) {
+                for (final Map.Entry<FilterBy, String> definedFilter : instance.filters.entrySet()) {
                     if (!acceptedFilters.contains(definedFilter.getKey())) {
                         throw new CotSdkException(String.format("This filter is not available in used api [%s]", definedFilter.getKey()));
                     }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -234,8 +234,8 @@ public class Filter {
          * @return an appropriate build Object
          */
         public FilterBuilder setFilters(HashMap<FilterBy, String> hashmap){
-            for (Map.Entry e : hashmap.entrySet()){
-                instance.arguments.put(((FilterBy)e.getKey()).getFilterKey(), (String) e.getValue());
+            for (Map.Entry<FilterBy, String> e : hashmap.entrySet()){
+                instance.arguments.put(e.getKey().getFilterKey(), e.getValue());
             }
             return this;
         }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -52,6 +52,7 @@ public class Filter {
          *
          * @return a string in pattern <code>arg1=val1&amp;arg2=val2</code>
          */
+        @Nonnull
         public String buildFilter() {
             String qs = "";
             Set<Map.Entry<String, String>> set = instance.arguments.entrySet();
@@ -69,6 +70,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder bySource(String id) {
             instance.arguments.put("source", id);
             return this;
@@ -81,6 +83,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byType(String type) {
             //instance.type = type;
             instance.arguments.put("type", type);
@@ -95,6 +98,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byDate(Date from, Date to) {
             //instance.dateFrom = from;
             //instance.dateTo = to;
@@ -110,6 +114,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byFragmentType(String fragmentType) {
             instance.arguments.put("fragmentType", fragmentType);
             return this;
@@ -122,6 +127,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byDeviceId(String deviceId) {
             instance.arguments.put("deviceId", deviceId);
             return this;
@@ -134,6 +140,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byStatus(OperationStatus operationStatus) {
             instance.arguments.put("status", operationStatus.toString());
             return this;
@@ -146,6 +153,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byText(String text) {
             instance.arguments.put("text", text);
             return this;
@@ -158,6 +166,7 @@ public class Filter {
          * @return an appropriate build Object.
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byListOfIds(String listOfIds) {
             instance.arguments.put("ids", listOfIds);
             return this;
@@ -171,6 +180,7 @@ public class Filter {
          * @since 0.3.0
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byStatus(String status) {
             instance.arguments.put("status", status);
             return this;
@@ -184,6 +194,7 @@ public class Filter {
          * @since 0.3.1
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byAgentId(String agentId) {
             instance.arguments.put("agentId", agentId);
             return this;
@@ -197,6 +208,7 @@ public class Filter {
          * @since 0.6.0
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byUser(String user) {
             instance.arguments.put("user", user);
             return this;
@@ -210,6 +222,7 @@ public class Filter {
          * @since 0.6.0
          */
         @Deprecated
+        @Nonnull
         public FilterBuilder byApplication(String application) {
             instance.arguments.put("application", application);
             return this;
@@ -222,6 +235,7 @@ public class Filter {
          * @param value value for filter, which should be added
          * @return an appropriate build Object
          */
+        @Nonnull
         public FilterBuilder setFilter(FilterBy filterBy, String value) {
            instance.arguments.put(filterBy.getFilterKey(), value);
            return this;
@@ -233,7 +247,8 @@ public class Filter {
          * @param hashmap contains enum values and vaslues for filter builds
          * @return an appropriate build Object
          */
-        public FilterBuilder setFilters(HashMap<FilterBy, String> hashmap){
+        @Nonnull
+        public FilterBuilder setFilters(@Nonnull HashMap<FilterBy, String> hashmap){
             for (Map.Entry<FilterBy, String> e : hashmap.entrySet()){
                 instance.arguments.put(e.getKey().getFilterKey(), e.getValue());
             }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -3,6 +3,7 @@ package com.telekom.m2m.cot.restsdk.util;
 import com.telekom.m2m.cot.restsdk.devicecontrol.OperationStatus;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.*;
 
 /**
@@ -244,7 +245,7 @@ public class Filter {
          *
          * @param filters list of filters, which have to be checked
          */
-        public void validateSupportedFilters(List filters) {
+        public void validateSupportedFilters(@Nullable List filters) {
             //do nothing, when filters is null
             if (filters != null) {
                 for (Map.Entry e : instance.arguments.entrySet()) {

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -245,9 +245,7 @@ public class Filter {
          */
         @Nonnull
         public FilterBuilder setFilters(@Nonnull final HashMap<FilterBy, String> filtersToAdd){
-            for (final Map.Entry<FilterBy, String> filter : filtersToAdd.entrySet()){
-                instance.arguments.put(filter.getKey(), filter.getValue());
-            }
+            instance.arguments.putAll(filtersToAdd);
             return this;
         }
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -263,7 +263,7 @@ public class Filter {
          * @param acceptedFilters list of filters, which are allowed. Pass null if all filters are allowed.
          * @throws CotSdkException If a filter that is not allowed is detected.
          */
-        public void validateSupportedFilters(@Nullable final List acceptedFilters) {
+        public void validateSupportedFilters(@Nullable final List<FilterBy> acceptedFilters) {
             // Do nothing, when all filters are accepted.
             if (acceptedFilters != null) {
                 for (final Map.Entry<String, String> definedFilter : instance.arguments.entrySet()) {

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -240,13 +240,13 @@ public class Filter {
         /**
          * adds a build for a hashmap of filters
          *
-         * @param hashmap contains enum values and values for filter builds
+         * @param filtersToAdd contains enum values and values for filter builds
          * @return an appropriate build Object
          */
         @Nonnull
-        public FilterBuilder setFilters(@Nonnull final HashMap<FilterBy, String> hashmap){
-            for (final Map.Entry<FilterBy, String> e : hashmap.entrySet()){
-                instance.arguments.put(e.getKey(), e.getValue());
+        public FilterBuilder setFilters(@Nonnull final HashMap<FilterBy, String> filtersToAdd){
+            for (final Map.Entry<FilterBy, String> filter : filtersToAdd.entrySet()){
+                instance.arguments.put(filter.getKey(), filter.getValue());
             }
             return this;
         }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -1,6 +1,8 @@
 package com.telekom.m2m.cot.restsdk.util;
 
 import com.telekom.m2m.cot.restsdk.devicecontrol.OperationStatus;
+
+import javax.annotation.Nonnull;
 import java.util.*;
 
 /**
@@ -21,6 +23,7 @@ public class Filter {
      *
      * @return FilterBuilder.
      */
+    @Nonnull
     public static FilterBuilder build() {
         return new FilterBuilder();
     }
@@ -229,7 +232,7 @@ public class Filter {
          * @return an appropriate build Object
          */
         public FilterBuilder setFilters(HashMap<FilterBy, String> hashmap){
-            for ( Map.Entry e : hashmap.entrySet() ){
+            for (Map.Entry e : hashmap.entrySet()){
                 instance.arguments.put(((FilterBy)e.getKey()).getFilterKey(), (String) e.getValue());
             }
             return this;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -65,7 +65,6 @@ public class Filter {
          * @param id ID of the source ({@link com.telekom.m2m.cot.restsdk.inventory.ManagedObject}) to build for.
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder bySource(String id) {
             filters.put(FilterBy.BYSOURCE, id);
@@ -78,7 +77,6 @@ public class Filter {
          * @param type type to build for.
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byType(String type) {
             filters.put(FilterBy.BYTYPE, type);
@@ -92,7 +90,6 @@ public class Filter {
          * @param to   end of the date range (more in the future).
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byDate(Date from, Date to) {
             filters.put(FilterBy.BYDATEFROM, CotUtils.convertDateToTimestring(from));
@@ -106,7 +103,6 @@ public class Filter {
          * @param fragmentType to build for.
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byFragmentType(String fragmentType) {
             filters.put(FilterBy.BYFRAGMENTTYPE, fragmentType);
@@ -119,7 +115,6 @@ public class Filter {
          * @param deviceId to build for.
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byDeviceId(String deviceId) {
             filters.put(FilterBy.BYDEVICEID, deviceId);
@@ -132,7 +127,6 @@ public class Filter {
          * @param operationStatus to build for.
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byStatus(OperationStatus operationStatus) {
             filters.put(FilterBy.BYSTATUS, operationStatus.toString());
@@ -145,7 +139,6 @@ public class Filter {
          * @param text to build for.
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byText(String text) {
             filters.put(FilterBy.BYTEXT, text);
@@ -158,7 +151,6 @@ public class Filter {
          * @param listOfIds to build for (comma separated).
          * @return an appropriate build Object.
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byListOfIds(String listOfIds) {
             filters.put(FilterBy.BYLISTOFIDs, listOfIds);
@@ -172,7 +164,6 @@ public class Filter {
          * @return an appropriate build Object.
          * @since 0.3.0
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byStatus(String status) {
             filters.put(FilterBy.BYSTATUS, status);
@@ -186,7 +177,6 @@ public class Filter {
          * @return an appropriate build Object.
          * @since 0.3.1
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byAgentId(String agentId) {
             filters.put(FilterBy.BYAGENTID, agentId);
@@ -200,7 +190,6 @@ public class Filter {
          * @return an appropriate build Object.
          * @since 0.6.0
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byUser(String user) {
             filters.put(FilterBy.BYUSER, user);
@@ -214,7 +203,6 @@ public class Filter {
          * @return an appropriate build Object.
          * @since 0.6.0
          */
-        @Deprecated
         @Nonnull
         public FilterBuilder byApplication(String application) {
             filters.put(FilterBy.BYAPPLICATION, application);

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -246,7 +246,7 @@ public class Filter {
         /**
          * adds a build for a hashmap of filters
          *
-         * @param hashmap contains enum values and vaslues for filter builds
+         * @param hashmap contains enum values and values for filter builds
          * @return an appropriate build Object
          */
         @Nonnull

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -45,7 +45,9 @@ public class Filter {
      * </pre>
      */
     public static class FilterBuilder {
-        private Filter instance = new Filter();
+
+        @Nonnull
+        private final Filter instance = new Filter();
 
         /**
          * Creates a parameter string.

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -15,9 +15,6 @@ import java.util.stream.Collectors;
  */
 public class Filter {
 
-    @Nonnull
-    private final HashMap<FilterBy, String> filters = new HashMap<>();
-
     private Filter() {
     }
 
@@ -48,7 +45,7 @@ public class Filter {
     public static class FilterBuilder {
 
         @Nonnull
-        private final Filter instance = new Filter();
+        private final HashMap<FilterBy, String> filters = new HashMap<>();
 
         /**
          * Creates a parameter string.
@@ -57,7 +54,7 @@ public class Filter {
          */
         @Nonnull
         public String buildFilter() {
-            return instance.filters.entrySet().stream()
+            return filters.entrySet().stream()
                 .map(filter -> filter.getKey().getFilterKey() + "=" + filter.getValue())
                 .collect(Collectors.joining("&"));
         }
@@ -71,7 +68,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder bySource(String id) {
-            instance.filters.put(FilterBy.BYSOURCE, id);
+            filters.put(FilterBy.BYSOURCE, id);
             return this;
         }
 
@@ -84,7 +81,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byType(String type) {
-            instance.filters.put(FilterBy.BYTYPE, type);
+            filters.put(FilterBy.BYTYPE, type);
             return this;
         }
 
@@ -98,8 +95,8 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byDate(Date from, Date to) {
-            instance.filters.put(FilterBy.BYDATEFROM, CotUtils.convertDateToTimestring(from));
-            instance.filters.put(FilterBy.BYDATETO, CotUtils.convertDateToTimestring(to));
+            filters.put(FilterBy.BYDATEFROM, CotUtils.convertDateToTimestring(from));
+            filters.put(FilterBy.BYDATETO, CotUtils.convertDateToTimestring(to));
             return this;
         }
 
@@ -112,7 +109,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byFragmentType(String fragmentType) {
-            instance.filters.put(FilterBy.BYFRAGMENTTYPE, fragmentType);
+            filters.put(FilterBy.BYFRAGMENTTYPE, fragmentType);
             return this;
         }
 
@@ -125,7 +122,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byDeviceId(String deviceId) {
-            instance.filters.put(FilterBy.BYDEVICEID, deviceId);
+            filters.put(FilterBy.BYDEVICEID, deviceId);
             return this;
         }
 
@@ -138,7 +135,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byStatus(OperationStatus operationStatus) {
-            instance.filters.put(FilterBy.BYSTATUS, operationStatus.toString());
+            filters.put(FilterBy.BYSTATUS, operationStatus.toString());
             return this;
         }
 
@@ -151,7 +148,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byText(String text) {
-            instance.filters.put(FilterBy.BYTEXT, text);
+            filters.put(FilterBy.BYTEXT, text);
             return this;
         }
 
@@ -164,7 +161,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byListOfIds(String listOfIds) {
-            instance.filters.put(FilterBy.BYLISTOFIDs, listOfIds);
+            filters.put(FilterBy.BYLISTOFIDs, listOfIds);
             return this;
         }
 
@@ -178,7 +175,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byStatus(String status) {
-            instance.filters.put(FilterBy.BYSTATUS, status);
+            filters.put(FilterBy.BYSTATUS, status);
             return this;
         }
 
@@ -192,7 +189,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byAgentId(String agentId) {
-            instance.filters.put(FilterBy.BYAGENTID, agentId);
+            filters.put(FilterBy.BYAGENTID, agentId);
             return this;
         }
 
@@ -206,7 +203,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byUser(String user) {
-            instance.filters.put(FilterBy.BYUSER, user);
+            filters.put(FilterBy.BYUSER, user);
             return this;
         }
         
@@ -220,7 +217,7 @@ public class Filter {
         @Deprecated
         @Nonnull
         public FilterBuilder byApplication(String application) {
-            instance.filters.put(FilterBy.BYAPPLICATION, application);
+            filters.put(FilterBy.BYAPPLICATION, application);
             return this;
         }
 
@@ -233,7 +230,7 @@ public class Filter {
          */
         @Nonnull
         public FilterBuilder setFilter(@Nonnull final FilterBy filterBy, @Nonnull final String value) {
-           instance.filters.put(filterBy, value);
+           filters.put(filterBy, value);
            return this;
         }
 
@@ -245,7 +242,7 @@ public class Filter {
          */
         @Nonnull
         public FilterBuilder setFilters(@Nonnull final Map<FilterBy, String> filtersToAdd){
-            instance.filters.putAll(filtersToAdd);
+            filters.putAll(filtersToAdd);
             return this;
         }
 
@@ -258,7 +255,7 @@ public class Filter {
         public void validateSupportedFilters(@Nullable final List<FilterBy> acceptedFilters) {
             // Do nothing, when all filters are accepted.
             if (acceptedFilters != null) {
-                for (final Map.Entry<FilterBy, String> definedFilter : instance.filters.entrySet()) {
+                for (final Map.Entry<FilterBy, String> definedFilter : filters.entrySet()) {
                     if (!acceptedFilters.contains(definedFilter.getKey())) {
                         throw new CotSdkException(String.format("This filter is not available in used api [%s]", definedFilter.getKey()));
                     }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -265,7 +265,7 @@ public class Filter {
             if (filters != null) {
                 for (Map.Entry<String, String> e : instance.arguments.entrySet()) {
                     if (!filters.contains(FilterBy.getFilterBy(e.getKey()))) {
-                        throw new CotSdkException(String.format("This filter is not avaible in used api [%s]", e.getKey()));
+                        throw new CotSdkException(String.format("This filter is not available in used api [%s]", e.getKey()));
                     }
                 }
             }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -263,8 +263,8 @@ public class Filter {
         public void validateSupportedFilters(@Nullable List filters) {
             //do nothing, when filters is null
             if (filters != null) {
-                for (Map.Entry e : instance.arguments.entrySet()) {
-                    if (!filters.contains(FilterBy.getFilterBy((String) e.getKey()))) {
+                for (Map.Entry<String, String> e : instance.arguments.entrySet()) {
+                    if (!filters.contains(FilterBy.getFilterBy(e.getKey()))) {
                         throw new CotSdkException(String.format("This filter is not avaible in used api [%s]", e.getKey()));
                     }
                 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -58,7 +58,7 @@ public class Filter {
         @Nonnull
         public String buildFilter() {
             return instance.arguments.entrySet().stream()
-                .map(entry -> entry.getKey().getFilterKey() + "=" + entry.getValue())
+                .map(filter -> filter.getKey().getFilterKey() + "=" + filter.getValue())
                 .collect(Collectors.joining("&"));
         }
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -258,14 +258,15 @@ public class Filter {
         /**
          * validate all set filters allowed by the api
          *
-         * @param filters list of filters, which have to be checked
+         * @param notAllowedFilters list of filters, which are not allowed.
+         * @throws CotSdkException If a filter that is not allowed is detected.
          */
-        public void validateSupportedFilters(@Nullable List filters) {
-            //do nothing, when filters is null
-            if (filters != null) {
-                for (Map.Entry<String, String> e : instance.arguments.entrySet()) {
-                    if (!filters.contains(FilterBy.getFilterBy(e.getKey()))) {
-                        throw new CotSdkException(String.format("This filter is not available in used api [%s]", e.getKey()));
+        public void validateSupportedFilters(@Nullable final List notAllowedFilters) {
+            // Do nothing, when no filters are blacklisted.
+            if (notAllowedFilters != null) {
+                for (final Map.Entry<String, String> definedFilter : instance.arguments.entrySet()) {
+                    if (!notAllowedFilters.contains(FilterBy.getFilterBy(definedFilter.getKey()))) {
+                        throw new CotSdkException(String.format("This filter is not available in used api [%s]", definedFilter.getKey()));
                     }
                 }
             }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/Filter.java
@@ -58,7 +58,7 @@ public class Filter {
         @Nonnull
         public String buildFilter() {
             return instance.arguments.entrySet().stream()
-                .map(entry -> entry.getKey().toString() + "=" + entry.getValue())
+                .map(entry -> entry.getKey().getFilterKey() + "=" + entry.getValue())
                 .collect(Collectors.joining("&"));
         }
 

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
@@ -2,7 +2,7 @@ package com.telekom.m2m.cot.restsdk.util;
 
 public enum FilterBy {
     /**
-     * perrmitted filters from all apis
+     * permitted filters from all apis
      */
     BYSOURCE ("source"),
     BYSTATUS ("status"),

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
@@ -12,9 +12,9 @@ public enum FilterBy {
     BYDATETO ("dateTo"),
     BYFRAGMENTTYPE ("fragmentType"),
     BYDEVICEID ("deviceId"),
-    BYTEXT ("Text"),
+    BYTEXT ("text"),
     BYLISTOFIDs ("ids"),
-    BYUSER ("User"),
+    BYUSER ("user"),
     BYAPPLICATION ("application");
 
     private String filterKey;

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
@@ -18,6 +18,7 @@ public enum FilterBy {
     BYAPPLICATION ("application");
 
     private String filterKey;
+
     FilterBy(String filterKey) {
         this.filterKey = filterKey;
     }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
@@ -32,14 +32,14 @@ public enum FilterBy {
     }
 
     @Nonnull
-    public static FilterBy getFilterBy(@Nonnull final String filter) {
+    public static FilterBy getFilterBy(@Nonnull final String filterKey) {
 
-      for(FilterBy b : values()) {
-          if(b.getFilterKey().equalsIgnoreCase(filter)) {
-              return b;
+      for(final FilterBy filter : values()) {
+          if(filter.getFilterKey().equalsIgnoreCase(filterKey)) {
+              return filter;
           }
       }
-      throw new IllegalArgumentException(String.format("Couldn't find an enum for requested filter: [%s]", filter));
+      throw new IllegalArgumentException(String.format("Couldn't find an enum for requested filter: [%s]", filterKey));
     }
 
 }

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/FilterBy.java
@@ -1,5 +1,7 @@
 package com.telekom.m2m.cot.restsdk.util;
 
+import javax.annotation.Nonnull;
+
 public enum FilterBy {
     /**
      * permitted filters from all apis
@@ -17,17 +19,20 @@ public enum FilterBy {
     BYUSER ("user"),
     BYAPPLICATION ("application");
 
+    @Nonnull
     private String filterKey;
 
-    FilterBy(String filterKey) {
+    FilterBy(@Nonnull final String filterKey) {
         this.filterKey = filterKey;
     }
 
+    @Nonnull
     public String getFilterKey() {
         return filterKey;
     }
 
-    public static FilterBy getFilterBy(String filter) {
+    @Nonnull
+    public static FilterBy getFilterBy(@Nonnull final String filter) {
 
       for(FilterBy b : values()) {
           if(b.getFilterKey().equalsIgnoreCase(filter)) {
@@ -35,7 +40,6 @@ public enum FilterBy {
           }
       }
       throw new IllegalArgumentException(String.format("Couldn't find an enum for requested filter: [%s]", filter));
-
     }
 
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiCollectionIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiCollectionIT.java
@@ -12,13 +12,11 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * @author chuhlich

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiIT.java
@@ -15,7 +15,7 @@ import java.util.Date;
  */
 public class AlarmApiIT {
 
-    CloudOfThingsPlatform cotPlat = new CloudOfThingsPlatform(TestHelper.TEST_HOST, TestHelper.TEST_USERNAME, TestHelper.TEST_PASSWORD);
+    private CloudOfThingsPlatform cotPlat = new CloudOfThingsPlatform(TestHelper.TEST_HOST, TestHelper.TEST_USERNAME, TestHelper.TEST_PASSWORD);
     private ManagedObject testManagedObject;
 
     @BeforeClass

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiIT.java
@@ -44,7 +44,7 @@ public class AlarmApiIT {
         AlarmApi alarmApi = cotPlat.getAlarmApi();
 
         Alarm createdAlarm = alarmApi.create(alarm);
-        Assert.assertNotNull("Should now have an Id", createdAlarm.getId());
+        Assert.assertNotNull(createdAlarm.getId(), "Should now have an Id");
     }
 
     @Test
@@ -63,7 +63,7 @@ public class AlarmApiIT {
         AlarmApi alarmApi = cotPlat.getAlarmApi();
 
         Alarm createdAlarm = alarmApi.create(alarm);
-        Assert.assertNotNull("Should now have an Id", createdAlarm.getId());
+        Assert.assertNotNull(createdAlarm.getId(), "Should now have an Id");
 
         Alarm retrievedAlarm = alarmApi.getAlarm(createdAlarm.getId());
         Assert.assertEquals(retrievedAlarm.getId(), createdAlarm.getId());
@@ -91,7 +91,7 @@ public class AlarmApiIT {
         AlarmApi alarmApi = cotPlat.getAlarmApi();
 
         Alarm createdAlarm = alarmApi.create(alarm);
-        Assert.assertNotNull("Should now have an Id", createdAlarm.getId());
+        Assert.assertNotNull(createdAlarm.getId(), "Should now have an Id");
 
         Alarm retrievedAlarm = alarmApi.getAlarm(createdAlarm.getId());
         Assert.assertEquals(retrievedAlarm.getId(), createdAlarm.getId());

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -14,16 +14,6 @@ import static org.mockito.Matchers.any;
  * Created by Patrick Steinert on 03.02.16.
  */
 public class AlarmApiTest {
-//    @Test(expectedExceptions = CotSdkException.class)
-//    public void testGetEventWithFailure() throws Exception {
-//        CloudOfThingsRestClient rc = Mockito.mock(CloudOfThingsRestClient.class);
-//        CloudOfThingsPlatform platform = Mockito.mock(CloudOfThingsPlatform.class);
-//        Mockito.when(platform.getEventApi()).thenReturn(new EventApi(rc));
-//        Mockito.doThrow(CotSdkException.class).when(rc).getResponse(any(String.class), any(String.class), any(String.class));
-//
-//        EventApi eventApi = platform.getEventApi();
-//        eventApi.getEvent("foo");
-//    }
 
     @Test
     public void testGetAlarm() throws Exception {
@@ -61,7 +51,5 @@ public class AlarmApiTest {
         Assert.assertEquals(alarm.getTime().compareTo(new Date(1315310607845L)), 0);
 
         Assert.assertNotNull(alarm.get("com_mycorp_MyProp"));
-        //Assert.assertEquals(alarm.getSource().getId(), "12345");
-
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Matchers.any;
 public class AlarmApiTest {
 
     @Test
-    public void testGetAlarm() throws Exception {
+    public void testGetAlarm() {
 
         String alarmJsonExample = "{\n" +
                 "  \"id\" : \"10\",\n" +

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -57,13 +57,20 @@ public class AlarmApiTest {
         Assert.assertNotNull(alarm.get("com_mycorp_MyProp"));
     }
 
+    @Test
+    public void deleteAlarmsWithoutFilterDoesNotThrowException() {
+        alarmApi.deleteAlarms(null);
+    }
+
     /**
      * @return A mocked Cloud of Things REST client.
      */
     @Nonnull
     private CloudOfThingsRestClient createClient() {
-        CloudOfThingsRestClient client = Mockito.mock(CloudOfThingsRestClient.class);
-        Mockito.when(client.getResponse(any(String.class), any(String.class), any(String.class))).thenReturn(ALARM_JSON_EXAMPLE);
+        final CloudOfThingsRestClient client = Mockito.mock(CloudOfThingsRestClient.class);
+        Mockito.doReturn(ALARM_JSON_EXAMPLE)
+            .when(client)
+            .getResponse(any(String.class), any(String.class), any(String.class));
         return client;
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -1,9 +1,9 @@
 package com.telekom.m2m.cot.restsdk.alarm;
 
-import com.telekom.m2m.cot.restsdk.CloudOfThingsPlatform;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
@@ -33,13 +33,19 @@ public class AlarmApiTest {
         "  }\n" +
         "}";
 
+    /**
+     * System under test.
+     */
+    private AlarmApi alarmApi;
+
+    @BeforeMethod
+    public void setup() {
+        CloudOfThingsRestClient client = createClient();
+        alarmApi = new AlarmApi(client);
+    }
+
     @Test
     public void testGetAlarm() {
-
-        CloudOfThingsRestClient client = createClient();
-
-
-        AlarmApi alarmApi = new AlarmApi(client);
         Alarm alarm = alarmApi.getAlarm("10");
 
         Assert.assertEquals(alarm.getId(), "10");

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -1,6 +1,7 @@
 package com.telekom.m2m.cot.restsdk.alarm;
 
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import com.telekom.m2m.cot.restsdk.util.Filter;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -60,6 +61,11 @@ public class AlarmApiTest {
     @Test
     public void deleteAlarmsWithoutFilterDoesNotThrowException() {
         alarmApi.deleteAlarms(null);
+    }
+
+    @Test
+    public void deleteAlarmsWithFilterDoesNotThrowException() {
+        alarmApi.deleteAlarms(Filter.build().bySource("test"));
     }
 
     /**

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import javax.annotation.Nonnull;
 import java.util.Date;
 
 import static org.mockito.Matchers.any;
@@ -15,28 +16,27 @@ import static org.mockito.Matchers.any;
  */
 public class AlarmApiTest {
 
+    private static final String ALARM_JSON_EXAMPLE = "{\n" +
+        "  \"id\" : \"10\",\n" +
+        "  \"self\" : \"<<Alarm URL>>\",\n" +
+        "  \"creationTime\" : \"2011-09-06T12:03:27.927Z\",\n" +
+        "  \"type\" : \"com_telekom_events_TamperEvent\",\n" +
+        "  \"time\" : \"2011-09-06T12:03:27.845Z\",\n" +
+        "  \"text\" : \"Tamper sensor triggered\",\n" +
+        "  \"status\" : \"ACTIVE\",\n" +
+        "  \"severity\" : \"MAJOR\",\n" +
+        "  \"source\" : { \"id\" : \"12345\", \"self\" : \"...\" },\n" +
+        "  \"com_mycorp_MyProp\" : {  },\n" +
+        "  \"history\" : {\n" +
+        "    \"self\" : \"...\",\n" +
+        "    \"auditRecords\" : [ ]\n" +
+        "  }\n" +
+        "}";
+
     @Test
     public void testGetAlarm() {
 
-        String alarmJsonExample = "{\n" +
-                "  \"id\" : \"10\",\n" +
-                "  \"self\" : \"<<Alarm URL>>\",\n" +
-                "  \"creationTime\" : \"2011-09-06T12:03:27.927Z\",\n" +
-                "  \"type\" : \"com_telekom_events_TamperEvent\",\n" +
-                "  \"time\" : \"2011-09-06T12:03:27.845Z\",\n" +
-                "  \"text\" : \"Tamper sensor triggered\",\n" +
-                "  \"status\" : \"ACTIVE\",\n" +
-                "  \"severity\" : \"MAJOR\",\n" +
-                "  \"source\" : { \"id\" : \"12345\", \"self\" : \"...\" },\n" +
-                "  \"com_mycorp_MyProp\" : {  },\n" +
-                "  \"history\" : {\n" +
-                "    \"self\" : \"...\",\n" +
-                "    \"auditRecords\" : [ ]\n" +
-                "  }\n" +
-                "}";
-
-        CloudOfThingsRestClient client = Mockito.mock(CloudOfThingsRestClient.class);
-        Mockito.when(client.getResponse(any(String.class), any(String.class), any(String.class))).thenReturn(alarmJsonExample);
+        CloudOfThingsRestClient client = createClient();
 
 
         AlarmApi alarmApi = new AlarmApi(client);
@@ -49,5 +49,15 @@ public class AlarmApiTest {
         Assert.assertEquals(alarm.getTime().compareTo(new Date(1315310607845L)), 0);
 
         Assert.assertNotNull(alarm.get("com_mycorp_MyProp"));
+    }
+
+    /**
+     * @return A mocked Cloud of Things REST client.
+     */
+    @Nonnull
+    private CloudOfThingsRestClient createClient() {
+        CloudOfThingsRestClient client = Mockito.mock(CloudOfThingsRestClient.class);
+        Mockito.when(client.getResponse(any(String.class), any(String.class), any(String.class))).thenReturn(ALARM_JSON_EXAMPLE);
+        return client;
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -35,13 +35,11 @@ public class AlarmApiTest {
                 "  }\n" +
                 "}";
 
-        CloudOfThingsRestClient rc = Mockito.mock(CloudOfThingsRestClient.class);
-        CloudOfThingsPlatform platform = Mockito.mock(CloudOfThingsPlatform.class);
-        Mockito.when(platform.getAlarmApi()).thenReturn(new AlarmApi(rc));
-        Mockito.when(rc.getResponse(any(String.class), any(String.class), any(String.class))).thenReturn(alarmJsonExample);
+        CloudOfThingsRestClient client = Mockito.mock(CloudOfThingsRestClient.class);
+        Mockito.when(client.getResponse(any(String.class), any(String.class), any(String.class))).thenReturn(alarmJsonExample);
 
 
-        AlarmApi alarmApi = platform.getAlarmApi();
+        AlarmApi alarmApi = new AlarmApi(client);
         Alarm alarm = alarmApi.getAlarm("10");
 
         Assert.assertEquals(alarm.getId(), "10");

--- a/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiTest.java
@@ -2,22 +2,43 @@ package com.telekom.m2m.cot.restsdk.measurement;
 
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.CotSdkException;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by Patrick Steinert on 07.02.16.
  */
 public class MeasurementApiTest {
 
+    /**
+     * System under test.
+     */
+    private MeasurementApi measurementApi;
+
+    /**
+     * Mocked client that is used by the test subject.
+     */
+    private CloudOfThingsRestClient restClient;
+
+    @BeforeMethod
+    public void setup() {
+        restClient = mock(CloudOfThingsRestClient.class);
+        measurementApi = new MeasurementApi(restClient);
+    }
+
     @Test(expectedExceptions = CotSdkException.class)
     public void testGetEventWithFailure() {
-        CloudOfThingsRestClient rc = Mockito.mock(CloudOfThingsRestClient.class);
-        Mockito.doThrow(CotSdkException.class).when(rc).getResponse(any(String.class), any(String.class), any(String.class));
+        doThrow(CotSdkException.class)
+            .when(restClient)
+            .getResponse(any(String.class), any(String.class), any(String.class));
 
-        MeasurementApi measurementApi = new MeasurementApi(rc);
         measurementApi.getMeasurement("1234");
     }
 

--- a/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiTest.java
@@ -2,15 +2,12 @@ package com.telekom.m2m.cot.restsdk.measurement;
 
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.CotSdkException;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
+import com.telekom.m2m.cot.restsdk.util.Filter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by Patrick Steinert on 07.02.16.
@@ -42,4 +39,22 @@ public class MeasurementApiTest {
         measurementApi.getMeasurement("1234");
     }
 
+    @Test(expectedExceptions = CotSdkException.class)
+    public void testThrowsExceptionIfClientReturnsNull() {
+        doReturn(null)
+            .when(restClient)
+            .getResponse(any(String.class), any(String.class), any(String.class));
+
+        measurementApi.getMeasurement("1234");
+    }
+
+    @Test
+    public void deleteMeasurementsDoesNotThrowExceptionIfNoFilterIsPassed() {
+        measurementApi.deleteMeasurements(null);
+    }
+
+    @Test
+    public void deleteMeasurementsDoesNotThrowExceptionIfFiltersAreProvided() {
+        measurementApi.deleteMeasurements(Filter.build().bySource("test"));
+    }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiTest.java
@@ -1,6 +1,5 @@
 package com.telekom.m2m.cot.restsdk.measurement;
 
-import com.telekom.m2m.cot.restsdk.CloudOfThingsPlatform;
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
 import com.telekom.m2m.cot.restsdk.util.CotSdkException;
 import org.mockito.Mockito;
@@ -14,13 +13,11 @@ import static org.mockito.Matchers.any;
 public class MeasurementApiTest {
 
     @Test(expectedExceptions = CotSdkException.class)
-    public void testGetEventWithFailure() throws Exception {
+    public void testGetEventWithFailure() {
         CloudOfThingsRestClient rc = Mockito.mock(CloudOfThingsRestClient.class);
-        CloudOfThingsPlatform platform = Mockito.mock(CloudOfThingsPlatform.class);
-        Mockito.when(platform.getMeasurementApi()).thenReturn(new MeasurementApi(rc));
         Mockito.doThrow(CotSdkException.class).when(rc).getResponse(any(String.class), any(String.class), any(String.class));
 
-        MeasurementApi measurementApi = platform.getMeasurementApi();
+        MeasurementApi measurementApi = new MeasurementApi(rc);
         measurementApi.getMeasurement("1234");
     }
 

--- a/src/test/java/com/telekom/m2m/cot/restsdk/users/UserApiIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/users/UserApiIT.java
@@ -200,8 +200,14 @@ public class UserApiIT {
         GroupReference groupReference2 = groupReferenceArray[1];
         Group groupRetrievedFromCot1 = groupReference1.getGroup();
         Group groupRetrievedFromCot2 = groupReference2.getGroup();
-        assertEquals(groupRetrievedFromCot1.getId(), returnedGroup1.getId(), "The group ID that the user is added to in the cloud should match to the group that is created locally.");
-        assertEquals(groupRetrievedFromCot2.getId(), returnedGroup2.getId(), "The group ID that the user is added to in the cloud should match to the group that is created locally.");
+
+        // Order of the group IDs that are returned from the CLoud of Things does not seem to be guaranteed.
+        // We check that all expected groups are referenced, regardless of the order.
+        assertEqualsNoOrder(
+            new Long[]{groupRetrievedFromCot1.getId(), groupRetrievedFromCot2.getId()},
+            new Long[]{returnedGroup1.getId(),returnedGroup2.getId()},
+            "The group IDs that the user is added to in the cloud should match to the group IDs that are created locally."
+        );
     }
 
     @Test

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterByTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterByTest.java
@@ -1,0 +1,26 @@
+package com.telekom.m2m.cot.restsdk.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class FilterByTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void getFilterByThrowsExceptionIfFilterDoesNotExist() {
+        exception.expect(IllegalArgumentException.class);
+        FilterBy.getFilterBy("this-is-missing");
+    }
+
+    @Test
+    public void getFilterByReturnsRequestedFilter() {
+        final FilterBy filter = FilterBy.getFilterBy(FilterBy.BYUSER.getFilterKey());
+
+        assertEquals(FilterBy.BYUSER, filter);
+    }
+}

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
@@ -70,6 +70,11 @@ public class FilterTest {
     }
 
     @Test
+    public void settingSameFilterAgainOverwritesPreviousValue() {
+
+    }
+
+    @Test
     public void setFilterAddsProvidedFilter() {
 
     }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
@@ -1,0 +1,96 @@
+package com.telekom.m2m.cot.restsdk.util;
+
+import org.junit.Test;
+
+public class FilterTest {
+
+    @Test
+    public void bySourceAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byTypeAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byDateAddsValuesToFilterString() {
+
+    }
+
+    @Test
+    public void byFragmentTypeAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byDeviceIdAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byStatusAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byStatusWithOperationParameterAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byTextAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byListOfIdsAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byAgentIdAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byUserAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void byApplicationAddsValueToFilterString() {
+
+    }
+
+    @Test
+    public void multipleFiltersAreCombined() {
+
+    }
+
+    @Test
+    public void setFilterAddsProvidedFilter() {
+
+    }
+
+    @Test
+    public void setFiltersAddsAllProvidedFilters() {
+
+    }
+
+    @Test
+    public void validateSupportedFiltersDoesNotThrowExceptionIfNullIsPassed() {
+
+    }
+
+    @Test
+    public void validateSupportedFiltersDoesNotThrowExceptionIfOnlyAcceptedFiltersHaveBeenAdded() {
+
+    }
+
+    @Test
+    public void validateSupportedFiltersThrowsExceptionIfNotAcceptedFilterHasBeenAdded() {
+
+    }
+}

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
@@ -1,101 +1,211 @@
 package com.telekom.m2m.cot.restsdk.util;
 
+import com.telekom.m2m.cot.restsdk.devicecontrol.OperationStatus;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.containsString;
 
 public class FilterTest {
 
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
     @Test
     public void bySourceAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byAgentId("42")
+            .buildFilter();
 
+        assertThat(filter, containsString("42"));
     }
 
     @Test
     public void byTypeAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byType("mqtt")
+            .buildFilter();
 
+        assertThat(filter, containsString("mqtt"));
     }
 
     @Test
     public void byDateAddsValuesToFilterString() {
+        final Instant start = LocalDate.of(2016, 1, 1)
+            .atStartOfDay(ZoneId.of("Europe/Berlin"))
+            .toInstant();
+        final Instant end = LocalDate.of(2017, 1, 1)
+            .atStartOfDay(ZoneId.of("Europe/Berlin"))
+            .toInstant();
 
+        final String filter = Filter.build()
+            .byDate(Date.from(start), Date.from(end))
+            .buildFilter();
+
+        assertThat(filter, containsString("2016"));
+        assertThat(filter, containsString("2017"));
     }
 
     @Test
     public void byFragmentTypeAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byFragmentType("test")
+            .buildFilter();
 
+        assertThat(filter, containsString("test"));
     }
 
     @Test
     public void byDeviceIdAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byDeviceId("42")
+            .buildFilter();
 
+        assertThat(filter, containsString("42"));
     }
 
     @Test
     public void byStatusAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byStatus("EXECUTING")
+            .buildFilter();
 
+        assertThat(filter, containsString("EXECUTING"));
     }
 
     @Test
     public void byStatusWithOperationParameterAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byStatus(OperationStatus.PENDING)
+            .buildFilter();
 
+        assertThat(filter, containsString(OperationStatus.PENDING.toString()));
     }
 
     @Test
     public void byTextAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byText("test")
+            .buildFilter();
 
+        assertThat(filter, containsString("test"));
     }
 
     @Test
     public void byListOfIdsAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byListOfIds("1,2,3")
+            .buildFilter();
 
+        assertThat(filter, containsString("1,2,3"));
     }
 
     @Test
     public void byAgentIdAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byAgentId("42")
+            .buildFilter();
 
+        assertThat(filter, containsString("42"));
     }
 
     @Test
     public void byUserAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byUser("matthias")
+            .buildFilter();
 
+        assertThat(filter, containsString("matthias"));
     }
 
     @Test
     public void byApplicationAddsValueToFilterString() {
+        final String filter = Filter.build()
+            .byApplication("unicorn")
+            .buildFilter();
 
+        assertThat(filter, containsString("unicorn"));
     }
 
     @Test
     public void multipleFiltersAreCombined() {
+        final String filter = Filter.build()
+            .byAgentId("42")
+            .byUser("matthias")
+            .buildFilter();
 
+        assertThat(filter, containsString("42"));
+        assertThat(filter, containsString("matthias"));
     }
 
     @Test
     public void settingSameFilterAgainOverwritesPreviousValue() {
+        final String filter = Filter.build()
+            .byUser("matthias")
+            .byUser("harry")
+            .buildFilter();
 
+        assertThat(filter, not(containsString("matthias")));
+        assertThat(filter, containsString("harry"));
     }
 
     @Test
     public void setFilterAddsProvidedFilter() {
+        final String filter = Filter.build()
+            .setFilter(FilterBy.BYTEXT, "test")
+            .buildFilter();
 
+        assertThat(filter, containsString("test"));
     }
 
     @Test
     public void setFiltersAddsAllProvidedFilters() {
+        final HashMap<FilterBy, String> filters = new HashMap<>();
+        filters.put(FilterBy.BYTEXT, "test");
+        filters.put(FilterBy.BYUSER, "matthias");
 
+        final String filter = Filter.build()
+            .setFilters(filters)
+            .buildFilter();
+
+        assertThat(filter, containsString("test"));
+        assertThat(filter, containsString("matthias"));
     }
 
     @Test
     public void validateSupportedFiltersDoesNotThrowExceptionIfNullIsPassed() {
+        final Filter.FilterBuilder builder = Filter.build()
+            .byAgentId("42");
 
+        // This should not throw an exception.
+        builder.validateSupportedFilters(null);
     }
 
     @Test
     public void validateSupportedFiltersDoesNotThrowExceptionIfOnlyAcceptedFiltersHaveBeenAdded() {
+        final Filter.FilterBuilder builder = Filter.build()
+            .byAgentId("42");
 
+        // This should not throw an exception.
+        builder.validateSupportedFilters(Collections.singletonList(FilterBy.BYAGENTID));
     }
 
     @Test
     public void validateSupportedFiltersThrowsExceptionIfNotAcceptedFilterHasBeenAdded() {
+        final Filter.FilterBuilder builder = Filter.build()
+            .byAgentId("42");
 
+        exception.expect(CotSdkException.class);
+        builder.validateSupportedFilters(Collections.singletonList(FilterBy.BYDEVICEID));
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/FilterTest.java
@@ -183,6 +183,15 @@ public class FilterTest {
     }
 
     @Test
+    public void usesCorrectFilterName() {
+        final String filter = Filter.build()
+            .byDeviceId("42")
+            .buildFilter();
+
+        assertThat(filter, containsString(FilterBy.BYDEVICEID.getFilterKey()));
+    }
+
+    @Test
     public void validateSupportedFiltersDoesNotThrowExceptionIfNullIsPassed() {
         final Filter.FilterBuilder builder = Filter.build()
             .byAgentId("42");


### PR DESCRIPTION
- Replaced filter names in `FilterBuilder` by `FilterBy` enums that have been introduced in a previous release.
- The helper methods that use these filters are not `@Deprecated` anymore.
- Fixed filter bugs: Several filter names were in wrong case. Therefore, these filters were ignored when applied. 
- Fixed potential NullPointer problems
- Added several unit tests.

fixes #71