### PR TITLE
PBT-823 fix deserialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ You can find the Java Doc of the latest release here: http://cloud-of-things.git
 
 Short information about what has changed between releases.
 
+### Release 2.0.0
+
+* Fix erroneously wrapped number values in deserialized ExtensibleObjects, e.g.:
+    serialized Object: temperature=ExtensibleObject{anyObject={unit=°C, value=100.0}} will be deserialized into:
+    OLD:
+    "temperature":{
+        "value":{
+            "value":"100.0"
+        },
+        "unit":"°C"
+    }
+    FIXED:
+    "temperature":{
+        "value":100.0,
+        "unit":"°C"
+    }
+
 ### Release 1.1.0
 
 * Includes [Pull Request #73](https://github.com/cloud-of-things/cot-java-rest-sdk/pull/73): Efficiently iterate over all objects in a collection via Java 8 Stream (accessible via `stream()`): pagination is automatically performed in the background

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Short information about what has changed between releases.
 
 ### Release 2.0.0
 
+* Prevent injection in update method
+* More robust deserialization catching IllegalArgumentException being thrown by Spring Boot Class Loader for properties like "A+:1" in ThreePhaseElectricityMeasurement.
 * Fix erroneously wrapped number values in deserialized ExtensibleObjects, e.g.:
     serialized Object: temperature=ExtensibleObject{anyObject={unit=°C, value=100.0}} will be deserialized into:
     OLD:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.telekom.m2m.cot</groupId>
     <artifactId>java-rest-client</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Cloud of Things Java REST SDK</name>
     <description>This is an SDK to interfere with the Cloud of Things by

--- a/src/main/java/com/telekom/m2m/cot/restsdk/util/ExtensibleObjectSerializer.java
+++ b/src/main/java/com/telekom/m2m/cot/restsdk/util/ExtensibleObjectSerializer.java
@@ -131,7 +131,7 @@ public class ExtensibleObjectSerializer implements JsonSerializer<ExtensibleObje
                     }
 
                 } else if (tmp.isNumber()) {
-                    converted = tmp.getAsNumber();
+                    converted = tmp.getAsBigDecimal();
                 }
                 mo.set(key, converted);
             } else if (value.isJsonObject()) {

--- a/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/alarm/AlarmApiTest.java
@@ -1,6 +1,7 @@
 package com.telekom.m2m.cot.restsdk.alarm;
 
 import com.telekom.m2m.cot.restsdk.CloudOfThingsRestClient;
+import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
 import com.telekom.m2m.cot.restsdk.util.Filter;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -8,6 +9,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
+import java.math.BigDecimal;
 import java.util.Date;
 
 import static org.mockito.Matchers.any;
@@ -27,7 +29,7 @@ public class AlarmApiTest {
         "  \"status\" : \"ACTIVE\",\n" +
         "  \"severity\" : \"MAJOR\",\n" +
         "  \"source\" : { \"id\" : \"12345\", \"self\" : \"...\" },\n" +
-        "  \"com_mycorp_MyProp\" : {  },\n" +
+        "  \"com_mycorp_MyProp\" : { \"prop1\": 123 },\n" +
         "  \"history\" : {\n" +
         "    \"self\" : \"...\",\n" +
         "    \"auditRecords\" : [ ]\n" +
@@ -55,7 +57,7 @@ public class AlarmApiTest {
         Assert.assertEquals(alarm.getCreationTime().compareTo(new Date(1315310607927L)), 0);
         Assert.assertEquals(alarm.getTime().compareTo(new Date(1315310607845L)), 0);
 
-        Assert.assertNotNull(alarm.get("com_mycorp_MyProp"));
+        Assert.assertEquals(((ExtensibleObject)alarm.get("com_mycorp_MyProp")).get("prop1"), new BigDecimal("123"));
     }
 
     @Test

--- a/src/test/java/com/telekom/m2m/cot/restsdk/event/EventTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/event/EventTest.java
@@ -44,9 +44,6 @@ public class EventTest {
         sts.setLat(50.722607);
         sts.setLon(7.144011);
 
-        Gson gs = new Gson();
-        String foo = gs.toJson(sts);
-
         Event event= new Event();
         event.setId("300001");
         event.setTime(date);
@@ -64,6 +61,5 @@ public class EventTest {
         Assert.assertEquals(ret.get("alt").getAsDouble(), 1000.0);
         Assert.assertEquals(ret.get("lat").getAsDouble(), 50.722607);
         Assert.assertEquals(ret.get("lon").getAsDouble(), 7.144011);
-
     }
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryApiExtendedIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/inventory/InventoryApiExtendedIT.java
@@ -265,8 +265,7 @@ public class InventoryApiExtendedIT {
     }
 
     private void createMeasurement(ManagedObject managedObject) {
-        SampleTemperatureSensor sampleTemperatureSensor = new SampleTemperatureSensor();
-        sampleTemperatureSensor.setTemperature(100);
+        SampleTemperatureSensor sampleTemperatureSensor = new SampleTemperatureSensor(100);
         Measurement testMeasurement = new Measurement();
         testMeasurement.setSource(managedObject);
         testMeasurement.setTime(new Date());

--- a/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiCollectionIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementApiCollectionIT.java
@@ -258,8 +258,7 @@ public class MeasurementApiCollectionIT {
 
     @Test
     public void testMultipleMeasurementsByTypeAndBySource() throws Exception {
-        SampleTemperatureSensor sts = new SampleTemperatureSensor();
-        sts.setTemperature(100);
+        SampleTemperatureSensor sts = new SampleTemperatureSensor(100);
         Measurement testMeasurement = new Measurement();
         testMeasurement.setSource(testManagedObject);
         testMeasurement.setTime(new Date(new Date().getTime() - (1000 * 60)));
@@ -288,8 +287,7 @@ public class MeasurementApiCollectionIT {
 
     @Test
     public void testMultipleMeasurementsByFragmentTypeAndBySource() throws Exception {
-        SampleTemperatureSensor sts = new SampleTemperatureSensor();
-        sts.setTemperature(100);
+        SampleTemperatureSensor sts = new SampleTemperatureSensor(100);
         Measurement testMeasurement = new Measurement();
         testMeasurement.setSource(testManagedObject);
         testMeasurement.setTime(new Date(new Date().getTime() - (1000 * 60)));

--- a/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementTest.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/measurement/MeasurementTest.java
@@ -1,13 +1,11 @@
 package com.telekom.m2m.cot.restsdk.measurement;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.telekom.m2m.cot.restsdk.util.ExtensibleObject;
-import com.telekom.m2m.cot.restsdk.util.GsonUtils;
-import com.telekom.m2m.cot.restsdk.util.SampleTemperatureSensor;
+import com.telekom.m2m.cot.restsdk.util.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.math.BigDecimal;
 import java.util.Date;
 
 /**
@@ -15,58 +13,150 @@ import java.util.Date;
  */
 public class MeasurementTest {
 
+    private final Gson gson = GsonUtils.createGson();
+
+    private final static String ID = "1234567";
+    private final static String TYPE = "ASpecialType";
+    private final static String CLASS_TYPE = "com_telekom_m2m_cot_restsdk_util_SampleTemperatureSensor";
+    private final static String FRAGMENT = "fragment";
+
     @Test
     public void testMeasurementSerialization() {
         Date date = new Date();
-
-        SampleTemperatureSensor sts = new SampleTemperatureSensor();
+        SampleTemperatureSensor sampleTemperatureSensor = new SampleTemperatureSensor(1);
 
         Measurement measurement = new Measurement();
-        measurement.setId("1234567");
+        measurement.setId(ID);
         measurement.setTime(date);
-        measurement.setType("ASpecialType");
-        measurement.set(sts);
+        measurement.setType(TYPE);
+        measurement.set(sampleTemperatureSensor);
 
-        Gson gson = GsonUtils.createGson();
         String json = gson.toJson(measurement);
 
         Measurement m = new Measurement(gson.fromJson(json, ExtensibleObject.class));
 
-        Assert.assertEquals(m.getId(), "1234567");
-        Assert.assertEquals(m.getType(), "ASpecialType");
+        Assert.assertEquals(m.getId(), ID);
+        Assert.assertEquals(m.getType(), TYPE);
         Assert.assertEquals(m.getTime().compareTo(date), 0);
-        Assert.assertNotNull(m.get("com_telekom_m2m_cot_restsdk_util_SampleTemperatureSensor"));
+        Assert.assertNotNull(m.get(CLASS_TYPE));
     }
 
     @Test
     public void testMeasurementFragmentSerialization() {
         Date date = new Date();
+        SampleTemperatureSensor sampleTemperatureSensor = new SampleTemperatureSensor(100);
 
+        Measurement measurement = new Measurement();
+        measurement.setId(ID);
+        measurement.setTime(date);
+        measurement.setType(TYPE);
+        measurement.set(sampleTemperatureSensor);
 
-        SampleTemperatureSensor sts = new SampleTemperatureSensor();
-        sts.setTemperature(100);
+        String serializedMeasurement = gson.toJson(measurement);
 
-        Gson gs = new Gson();
-        String foo = gs.toJson(sts);
+        Measurement deserializedMeasurement = new Measurement(gson.fromJson(serializedMeasurement, ExtensibleObject.class));
+        String reserializedMeasurement = gson.toJson(deserializedMeasurement);
 
-        Measurement measument = new Measurement();
-        measument.setId("1234567");
-        measument.setTime(date);
-        measument.setType("ASpecialType");
-        measument.set(sts);
+        Assert.assertEquals(reserializedMeasurement, serializedMeasurement);
+
+        Assert.assertEquals(deserializedMeasurement.getId(), ID);
+        Assert.assertEquals(deserializedMeasurement.getType(), TYPE);
+        Assert.assertEquals(deserializedMeasurement.getTime().compareTo(date), 0);
+        Assert.assertNotNull(deserializedMeasurement.get(CLASS_TYPE));
+        Assert.assertNotNull(((SampleTemperatureSensor)deserializedMeasurement.get(CLASS_TYPE)).getTemperature());
+        Assert.assertEquals(((SampleTemperatureSensor)deserializedMeasurement.get(CLASS_TYPE)).getTemperature().getValue(), sampleTemperatureSensor.getTemperature().getValue());
+        Assert.assertEquals(((SampleTemperatureSensor)deserializedMeasurement.get(CLASS_TYPE)).getTemperature().getUnit(), sampleTemperatureSensor.getTemperature().getUnit());
+    }
+
+    @Test
+    public void testMeasurementFragmentFloatValueSerialization() {
+        Date date = new Date();
+        SampleTemperatureSensor sampleTemperatureSensor = new SampleTemperatureSensor(100);
+
+        Measurement measurement = new Measurement();
+        measurement.setId(ID);
+        measurement.setTime(date);
+        measurement.setType(TYPE);
+        measurement.set(FRAGMENT, sampleTemperatureSensor);
+
+        String serializedMeasurement = gson.toJson(measurement);
+
+        Measurement deserializedMeasurement = new Measurement(gson.fromJson(serializedMeasurement, ExtensibleObject.class));
+        String reserializedMeasurement = gson.toJson(deserializedMeasurement);
+
+        Assert.assertEquals(reserializedMeasurement, serializedMeasurement);
+
+        Assert.assertEquals(deserializedMeasurement.getId(), ID);
+        Assert.assertEquals(deserializedMeasurement.getType(), TYPE);
+        Assert.assertEquals(deserializedMeasurement.getTime().compareTo(date), 0);
+        Assert.assertNotNull(deserializedMeasurement.get(FRAGMENT));
+        Assert.assertNotNull(((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("temperature"));
+        Assert.assertEquals(((ExtensibleObject)((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("temperature")).get("value"), new BigDecimal("" + sampleTemperatureSensor.getTemperature().getValue()));
+        Assert.assertEquals(((ExtensibleObject)((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("temperature")).get("unit"), sampleTemperatureSensor.getTemperature().getUnit());
+    }
+
+    @Test
+    public void testMeasurementFragmentBigDecimalReserialization() {
+        Date date = new Date();
+
+        SamplePowerSensor samplePowerSensor = new SamplePowerSensor(new MeasurementValue(new BigDecimal("-5730346.825124564"), "Wh"));
+
+        Measurement measurement = new Measurement();
+        measurement.setId(ID);
+        measurement.setTime(date);
+        measurement.setType(TYPE);
+        measurement.set(FRAGMENT, samplePowerSensor);
 
         Gson gson = GsonUtils.createGson();
-        String json = gson.toJson(measument);
+        String serializedMeasurement = gson.toJson(measurement);
 
-        JsonObject o = gson.fromJson(json, JsonObject.class);
+        Measurement deserializedMeasurement = new Measurement(gson.fromJson(serializedMeasurement, ExtensibleObject.class));
+        String reserializedMeasurement = gson.toJson(deserializedMeasurement);
 
-        Assert.assertEquals(o.get("id").getAsString(), "1234567");
-        Assert.assertNotNull(o.get("com_telekom_m2m_cot_restsdk_util_SampleTemperatureSensor"));
-        JsonObject ret = o.get("com_telekom_m2m_cot_restsdk_util_SampleTemperatureSensor").getAsJsonObject();
-        Assert.assertNotNull(ret.get("temperature"));
-        Assert.assertEquals(ret.get("temperature").getAsJsonObject().get("value").getAsFloat(), 100.0f);
-        Assert.assertEquals(ret.get("temperature").getAsJsonObject().get("unit").getAsString(), "°C");
+        Measurement deserializedMeasurement2 = new Measurement(gson.fromJson(reserializedMeasurement, ExtensibleObject.class));
+        String reserializedMeasurement2 = gson.toJson(deserializedMeasurement2);
 
+        Assert.assertEquals(reserializedMeasurement, serializedMeasurement);
+        Assert.assertEquals(reserializedMeasurement2, reserializedMeasurement);
+
+        Assert.assertNotNull(deserializedMeasurement.get(FRAGMENT));
+        Assert.assertNotNull(((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("solar"));
+        Assert.assertEquals(((ExtensibleObject)((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("solar")).get("value"), samplePowerSensor.getSolar().getValue());
+        Assert.assertEquals(((ExtensibleObject)((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("solar")).get("unit"), samplePowerSensor.getSolar().getUnit());
+    }
+
+    @Test
+    public void testMeasurementFragmentIntValueSerialization() {
+        Date date = new Date();
+
+        final int value = -10;
+        final String unit = "A";
+
+        Measurement measurement = new Measurement();
+        measurement.setId(ID);
+        measurement.setTime(date);
+        measurement.setType(TYPE);
+        ExtensibleObject fragment = new ExtensibleObject();
+        ExtensibleObject temperature = new ExtensibleObject();
+        temperature.set("value", value);
+        temperature.set("unit", unit);
+        fragment.set("current", temperature);
+        measurement.set(FRAGMENT, fragment);
+
+        String serializedMeasurement = gson.toJson(measurement);
+
+        Measurement deserializedMeasurement = new Measurement(gson.fromJson(serializedMeasurement, ExtensibleObject.class));
+        String reserializedMeasurement = gson.toJson(deserializedMeasurement);
+
+        Assert.assertEquals(reserializedMeasurement, serializedMeasurement);
+
+        Assert.assertEquals(deserializedMeasurement.getId(), ID);
+        Assert.assertEquals(deserializedMeasurement.getType(), TYPE);
+        Assert.assertEquals(deserializedMeasurement.getTime().compareTo(date), 0);
+        Assert.assertNotNull(deserializedMeasurement.get(FRAGMENT));
+        Assert.assertNotNull(((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("current"));
+        Assert.assertEquals(Integer.parseInt(((ExtensibleObject)((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("current")).get("value").toString()), value);
+        Assert.assertEquals(((ExtensibleObject)((ExtensibleObject)deserializedMeasurement.get(FRAGMENT)).get("current")).get("unit"), unit);
     }
 
 }

--- a/src/test/java/com/telekom/m2m/cot/restsdk/users/DevicePermissionIT.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/users/DevicePermissionIT.java
@@ -164,8 +164,7 @@ public class DevicePermissionIT {
     }
 
     private Measurement createMeasurement(ManagedObject managedObject, MeasurementApi measurementApi) {
-        SampleTemperatureSensor sts = new SampleTemperatureSensor();
-        sts.setTemperature(100);
+        SampleTemperatureSensor sts = new SampleTemperatureSensor(100);
         Measurement testMeasurement = new Measurement();
         testMeasurement.setSource(managedObject);
         testMeasurement.setTime(new Date());

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/MeasurementValue.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/MeasurementValue.java
@@ -1,0 +1,21 @@
+package com.telekom.m2m.cot.restsdk.util;
+
+import java.math.BigDecimal;
+
+public class MeasurementValue {
+    private BigDecimal value;
+    private String unit;
+
+    public MeasurementValue(BigDecimal value, String unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+}

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/SamplePowerSensor.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/SamplePowerSensor.java
@@ -1,0 +1,14 @@
+package com.telekom.m2m.cot.restsdk.util;
+
+public class SamplePowerSensor {
+
+    private MeasurementValue solar;
+
+    public SamplePowerSensor(MeasurementValue solar) {
+        this.solar = solar;
+    }
+
+    public MeasurementValue getSolar() {
+        return solar;
+    }
+}

--- a/src/test/java/com/telekom/m2m/cot/restsdk/util/SampleTemperatureSensor.java
+++ b/src/test/java/com/telekom/m2m/cot/restsdk/util/SampleTemperatureSensor.java
@@ -9,22 +9,11 @@ public class SampleTemperatureSensor {
 
     private MeasurementReading temperature;
 
-    public SampleTemperatureSensor() {
-
-    }
-
-    public SampleTemperatureSensor(MeasurementReading temperature) {
-        this.temperature = temperature;
+    public SampleTemperatureSensor(final float temperature) {
+        this.temperature = new MeasurementReading(temperature, "°C");
     }
 
     public MeasurementReading getTemperature() {
         return temperature;
     }
-
-
-    public void setTemperature(float temperature) {
-        this.temperature = new MeasurementReading("°C");
-        this.temperature.setValue(temperature);
-    }
-
 }


### PR DESCRIPTION
Problem:
if you create a measurement in c8y and retrieve it from c8y again, the measurement is packed into another JsonObject and the type is changed from float to string.
So the serialized object is no longer identical to the re-serialized object:

```
Expected: 
{
    "CalculatedPowerValuesPerMonth": {
      "solar": {
        "value": 5730347.0,
        "unit": "Wh"
      }
    },
    "id": "1234567",
    "time": "2020-06-10T13:27:31.696+02",
    "type": "CalculatedPowerValuesPerMonth"
  }

Actual: 
{
    "CalculatedPowerValuesPerMonth": {
      "solar": {
        "value": {
          "value": "5730347.0"
        },
        "unit": "Wh"
      }
    },
    "id": "1234567",
    "time": "2020-06-10T13:27:31.696+02",
    "type": "CalculatedPowerValuesPerMonth"
  }
```